### PR TITLE
fix: handle macOS Open With file URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Monight is a cross-platform PDF reader built with Tauri and TypeScript. It combines a lightweight native shell with a web-based UI for fast, native-feeling PDF viewing.
 
-Current version: `1.0.5`
+Current version: `1.0.6`
 
 ## Features
 - Multi-tab PDF viewing

--- a/docs/performance-benchmarks.md
+++ b/docs/performance-benchmarks.md
@@ -14,7 +14,7 @@ Open prerequisite issues at the time this scaffold was created:
 
 ## Methodology
 
-- App version: 1.0.5
+- App version: 1.0.6
 - Device: pending
 - Display: pending
 - Operating system: pending

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monight",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monight",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@tauri-apps/api": "~2.11.0",
         "@tauri-apps/plugin-dialog": "~2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monight",
   "private": true,
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "description": "Monight (墨页) - A modern PDF reader built with Tauri",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "monight"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "clap",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monight"
-version = "1.0.5"
+version = "1.0.6"
 description = "Monight (墨页) - A modern PDF reader"
 authors = ["Monight Team"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 
 use clap::Parser;
 use serde::Serialize;
+use std::path::PathBuf;
 use std::sync::Mutex;
 use tauri::{Emitter, Listener, Manager};
 
@@ -66,9 +67,90 @@ fn store_pending_payload(app: &tauri::AppHandle, payload: CliPayload) {
     store_pending_payload_inner(state.inner(), payload);
 }
 
+fn dispatch_open_payload(app: &tauri::AppHandle, payload: CliPayload) {
+    let _ = commands::fit_main_window_for_pdf(app.clone(), true);
+    store_pending_payload(app, payload.clone());
+
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.emit("cli-open-files", payload);
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+fn path_from_open_candidate(candidate: String) -> Option<PathBuf> {
+    let trimmed = candidate.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Ok(url) = url::Url::parse(trimmed) {
+        if url.scheme() == "file" {
+            return url.to_file_path().ok();
+        }
+    }
+
+    Some(PathBuf::from(trimmed))
+}
+
+pub(crate) fn paths_from_legacy_file_open_payload(payload: &str) -> Vec<PathBuf> {
+    if payload.is_empty() {
+        return Vec::new();
+    }
+
+    let mut files: Vec<String> = Vec::new();
+
+    if let Ok(list) = serde_json::from_str::<Vec<String>>(payload) {
+        files.extend(list);
+    } else if let Ok(single) = serde_json::from_str::<String>(payload) {
+        files.push(single);
+    } else {
+        files.push(payload.to_string());
+    }
+
+    files
+        .into_iter()
+        .filter_map(path_from_open_candidate)
+        .collect()
+}
+
+pub(crate) fn payload_from_file_paths<I>(files: I, page: Option<u32>) -> Option<CliPayload>
+where
+    I: IntoIterator<Item = PathBuf>,
+{
+    let valid_files = files
+        .into_iter()
+        .filter_map(|file| std::fs::canonicalize(file).ok())
+        .filter(|canonical| canonical.exists() && is_supported_extension(canonical))
+        .map(|canonical| canonical.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+
+    if valid_files.is_empty() {
+        None
+    } else {
+        Some(CliPayload {
+            files: valid_files,
+            page,
+        })
+    }
+}
+
+pub(crate) fn payload_from_opened_urls(urls: &[url::Url]) -> Option<CliPayload> {
+    payload_from_file_paths(
+        urls.iter().filter_map(|url| {
+            if url.scheme() == "file" {
+                url.to_file_path().ok()
+            } else {
+                None
+            }
+        }),
+        None,
+    )
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let app = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_shell::init())
@@ -99,78 +181,26 @@ pub fn run() {
             // macOS/iOS/Windows send tauri://file-open event
             #[cfg(any(target_os = "macos", target_os = "ios", target_os = "windows"))]
             {
-                let window_for_open = window.clone();
                 let app_handle_for_open = app_handle.clone();
                 app_handle.listen("tauri://file-open", move |event| {
                     let payload = event.payload();
-                    if payload.is_empty() {
-                        return;
-                    }
-
-                    let mut files: Vec<String> = Vec::new();
-
-                    if let Ok(list) = serde_json::from_str::<Vec<String>>(payload) {
-                        files.extend(list);
-                    } else if let Ok(single) = serde_json::from_str::<String>(payload) {
-                        files.push(single);
-                    } else {
-                        files.push(payload.to_string());
-                    }
-
-                    let mut valid_files = Vec::new();
-                    for file_path in files {
-                        if let Ok(canonical) = std::fs::canonicalize(&file_path) {
-                            if canonical.exists() && is_supported_extension(&canonical) {
-                                valid_files.push(canonical.to_string_lossy().to_string());
-                            }
-                        }
-                    }
-
-                    if !valid_files.is_empty() {
-                        let payload = CliPayload {
-                            files: valid_files,
-                            page: None,
-                        };
-                        let _ =
-                            commands::fit_main_window_for_pdf(app_handle_for_open.clone(), true);
-                        store_pending_payload(&app_handle_for_open, payload.clone());
-                        let _ = window_for_open.emit("cli-open-files", payload);
+                    if let Some(payload) =
+                        payload_from_file_paths(paths_from_legacy_file_open_payload(payload), None)
+                    {
+                        dispatch_open_payload(&app_handle_for_open, payload);
                     }
                 });
             }
 
             // If files were provided via CLI, emit event to frontend
             if !cli.files.is_empty() {
-                // Validate and canonicalize paths
-                let mut valid_files = Vec::new();
-                for file in cli.files {
-                    if let Ok(canonical) = std::fs::canonicalize(&file) {
-                        if canonical.exists() && is_supported_extension(&canonical) {
-                            valid_files.push(canonical.to_string_lossy().to_string());
-                        } else {
-                            #[cfg(debug_assertions)]
-                            eprintln!("File not found: {}", file);
-                        }
-                    } else {
-                        #[cfg(debug_assertions)]
-                        eprintln!("Invalid path: {}", file);
-                    }
-                }
-
-                // Only emit if we have valid files
-                if !valid_files.is_empty() {
-                    let payload = CliPayload {
-                        files: valid_files,
-                        page: cli.page,
-                    };
-
+                let paths = cli.files.into_iter().map(PathBuf::from);
+                if let Some(payload) = payload_from_file_paths(paths, cli.page) {
                     #[cfg(debug_assertions)]
                     println!("Opening files from CLI: {:?}", payload.files);
 
                     // Store and emit event (frontend will also pull pending on ready)
-                    let _ = commands::fit_main_window_for_pdf(app_handle.clone(), true);
-                    store_pending_payload(&app_handle, payload.clone());
-                    window.emit("cli-open-files", payload)?;
+                    dispatch_open_payload(&app_handle, payload);
                 }
             }
 
@@ -186,8 +216,17 @@ pub fn run() {
         .on_menu_event(|app, event| {
             menu::handle_menu_event(app, event.id().as_ref());
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application");
+
+    app.run(|app, event| {
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
+        if let tauri::RunEvent::Opened { urls } = event {
+            if let Some(payload) = payload_from_opened_urls(&urls) {
+                dispatch_open_payload(app, payload);
+            }
+        }
+    });
 }
 
 #[cfg(test)]
@@ -220,5 +259,47 @@ mod tests {
         let merged = take_cli_payload_inner(&state).expect("merged payload should be present");
         assert_eq!(merged.files, vec!["/tmp/one.pdf", "/tmp/two.pdf"]);
         assert_eq!(merged.page, Some(7));
+    }
+
+    #[test]
+    fn test_legacy_file_open_payload_accepts_raw_path() {
+        let fixture =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sample.pdf");
+
+        let payload = payload_from_file_paths(
+            paths_from_legacy_file_open_payload(fixture.to_string_lossy().as_ref()),
+            None,
+        )
+        .expect("raw path payload should be accepted");
+
+        assert_eq!(payload.files, vec![fixture.to_string_lossy().to_string()]);
+        assert_eq!(payload.page, None);
+    }
+
+    #[test]
+    fn test_legacy_file_open_payload_accepts_file_url() {
+        let fixture =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sample.pdf");
+        let file_url = url::Url::from_file_path(&fixture).expect("fixture should become file URL");
+
+        let payload =
+            payload_from_file_paths(paths_from_legacy_file_open_payload(file_url.as_str()), None)
+                .expect("file URL payload should be accepted");
+
+        assert_eq!(payload.files, vec![fixture.to_string_lossy().to_string()]);
+        assert_eq!(payload.page, None);
+    }
+
+    #[test]
+    fn test_opened_urls_accepts_file_urls() {
+        let fixture =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sample.pdf");
+        let file_url = url::Url::from_file_path(&fixture).expect("fixture should become file URL");
+
+        let payload =
+            payload_from_opened_urls(&[file_url]).expect("opened file URL should be accepted");
+
+        assert_eq!(payload.files, vec![fixture.to_string_lossy().to_string()]);
+        assert_eq!(payload.page, None);
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Monight",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "identifier": "art.monight.www",
   "build": {
     "frontendDist": "../dist",

--- a/src/__tests__/performance-benchmarks.test.ts
+++ b/src/__tests__/performance-benchmarks.test.ts
@@ -10,7 +10,7 @@ import {
 describe('createBenchmarkReport', () => {
   it('creates a report entry for each required issue 7 benchmark category', () => {
     const report = createBenchmarkReport({
-      appVersion: '1.0.5',
+      appVersion: '1.0.6',
       device: 'MacBook Pro M3',
       display: '3024x1964 @ 2x',
       testFiles: ['long-document.pdf: 400 pages, 120 MB'],
@@ -27,7 +27,7 @@ describe('createBenchmarkReport', () => {
 
   it('formats the report as one markdown baseline document with methodology context', () => {
     const report = createBenchmarkReport({
-      appVersion: '1.0.5',
+      appVersion: '1.0.6',
       device: 'MacBook Pro M3',
       display: '3024x1964 @ 2x',
       testFiles: ['long-document.pdf: 400 pages, 120 MB'],
@@ -37,7 +37,7 @@ describe('createBenchmarkReport', () => {
     const markdown = formatBenchmarkReport(report);
 
     expect(markdown).toContain('# Performance Benchmark Report');
-    expect(markdown).toContain('- App version: 1.0.5');
+    expect(markdown).toContain('- App version: 1.0.6');
     expect(markdown).toContain('- Device: MacBook Pro M3');
     expect(markdown).toContain('- Display: 3024x1964 @ 2x');
     expect(markdown).toContain('- Test files: long-document.pdf: 400 pages, 120 MB');
@@ -50,7 +50,7 @@ describe('createBenchmarkReport', () => {
 
   it('reports missing measurements and pending human review before the baseline is complete', () => {
     const report = createBenchmarkReport({
-      appVersion: '1.0.5',
+      appVersion: '1.0.6',
       device: 'MacBook Pro M3',
       display: '3024x1964 @ 2x',
       testFiles: ['long-document.pdf: 400 pages, 120 MB'],

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,7 @@ async function getAppInfo(): Promise<AppInfo> {
     return { name, version, tauriVersion };
   } catch (error) {
     console.error('Failed to get app info:', error);
-    return { name: 'Monight', version: '1.0.5', tauriVersion: 'Unknown' };
+    return { name: 'Monight', version: '1.0.6', tauriVersion: 'Unknown' };
   }
 }
 

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -31,7 +31,7 @@ export interface MoonightSettings {
  * Default settings
  */
 export const DEFAULT_SETTINGS: MoonightSettings = {
-  version: '1.0.5',
+  version: '1.0.6',
   general: {
     maximizeOnOpen: true,
     displayThumbs: true,


### PR DESCRIPTION
Root cause: Finder/Open With on macOS is delivered through Tauri 2 as app-level opened file URLs, while Monight only handled CLI arguments and a narrow legacy tauri://file-open payload shape. file:// payloads were treated as filesystem paths and dropped before the frontend could open the document.

Fix: normalize raw paths and file:// URLs into the existing CliPayload model, canonicalize supported document paths once, and dispatch every OS-open path through the same pending-payload plus cli-open-files frontend event flow used by CLI opens. The dispatcher also restores/shows/focuses the main window when an external open request arrives.

Regression coverage: add Rust tests for raw legacy paths, legacy file:// payloads, and Tauri RunEvent::Opened file URLs so the Finder/Open With path stays covered.

Release: bump Monight app metadata, package lockfiles, Tauri/Cargo metadata, default settings fallback, docs, and version-sensitive tests from 1.0.5 to 1.0.6.

Verification: cargo test; npm test; npm run lint; npm run build; npm run tauri:build. The packaging build produced Monight_1.0.6_aarch64.dmg.