### PR TITLE
Restore previous reading sessions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,9 @@
+# Monight
+
+Monight is a PDF reader focused on keeping a reader's documents and visual reading preferences available across app launches.
+
+## Language
+
+**Reading Session**:
+The set of PDFs a reader has open, including which document is active and each document's reading position and visual state.
+_Avoid_: Last file, startup files, window state

--- a/settings.html
+++ b/settings.html
@@ -425,6 +425,18 @@
                 </div>
                 <div class="setting-item">
                     <div class="setting-label">
+                        <h3>Restore Previous Session</h3>
+                        <p>Reopen tabs, active document, page, zoom, filter, and view mode on launch</p>
+                    </div>
+                    <div class="setting-control">
+                        <label class="toggle-switch">
+                            <input type="checkbox" id="restorePreviousSession">
+                            <span class="toggle-slider"></span>
+                        </label>
+                    </div>
+                </div>
+                <div class="setting-item">
+                    <div class="setting-label">
                         <h3>Continuous Scroll by Default</h3>
                         <p>Open PDFs in continuous scroll view</p>
                     </div>

--- a/src/app/session-state.ts
+++ b/src/app/session-state.ts
@@ -1,0 +1,101 @@
+import type { FilterSettings } from '../scripts/filters';
+import type { ReadingSession, SavedTabSession } from '../scripts/settings';
+import type { SliderManager } from '../scripts/sliders';
+import type { TabData, TabManager } from '../scripts/tabs';
+import { openFiles } from './file-actions';
+import { restoreTabState } from './tab-state';
+
+export interface RestoreSessionResult {
+  opened: number;
+  failed: number;
+}
+
+interface RestoreSessionOptions {
+  tabManager: TabManager;
+  sliderManager: SliderManager | null;
+  getInitialFilterSettings: () => FilterSettings;
+  getInitialViewMode: () => 'single' | 'continuous';
+}
+
+function toSavedTabSession(tab: TabData): SavedTabSession {
+  return {
+    filePath: tab.filePath,
+    title: tab.title,
+    filterSettings: { ...tab.filterSettings },
+    currentPage: tab.currentPage,
+    zoom: tab.zoom,
+    viewMode: tab.viewMode,
+  };
+}
+
+export function captureReadingSession(tabManager: TabManager | null): ReadingSession {
+  const activeTab = tabManager?.getActiveTab() ?? null;
+
+  return {
+    version: 1,
+    activeFilePath: activeTab?.filePath ?? null,
+    tabs: tabManager?.getTabs().map(toSavedTabSession) ?? [],
+  };
+}
+
+async function restoreSavedTab(
+  savedTab: SavedTabSession,
+  {
+    tabManager,
+    sliderManager,
+    getInitialFilterSettings,
+    getInitialViewMode,
+  }: RestoreSessionOptions,
+): Promise<boolean> {
+  const opened = await openFiles([savedTab.filePath], {
+    tabManager,
+    continueOnError: true,
+    onError: (message) => console.warn(message),
+    initialFilterSettings: savedTab.filterSettings ?? getInitialFilterSettings(),
+    initialViewMode: savedTab.viewMode ?? getInitialViewMode(),
+  });
+
+  const restoredTab = tabManager.getTabs().find((tab) => tab.filePath === savedTab.filePath);
+
+  if (opened === 0 || !restoredTab) {
+    return false;
+  }
+
+  restoredTab.title = savedTab.title;
+  restoredTab.filterSettings = { ...savedTab.filterSettings };
+  restoredTab.currentPage = savedTab.currentPage;
+  restoredTab.zoom = savedTab.zoom;
+  restoredTab.viewMode = savedTab.viewMode;
+
+  await restoreTabState(tabManager, sliderManager, restoredTab);
+  return true;
+}
+
+export async function restoreReadingSession(
+  session: ReadingSession,
+  options: RestoreSessionOptions,
+): Promise<RestoreSessionResult> {
+  let opened = 0;
+  let failed = 0;
+
+  for (const savedTab of session.tabs) {
+    const restored = await restoreSavedTab(savedTab, options);
+    if (restored) {
+      opened += 1;
+    } else {
+      failed += 1;
+    }
+  }
+
+  if (session.activeFilePath) {
+    const activeTab = options.tabManager
+      .getTabs()
+      .find((tab) => tab.filePath === session.activeFilePath);
+
+    if (activeTab) {
+      await options.tabManager.activateTab(activeTab.id);
+    }
+  }
+
+  return { opened, failed };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import {
   updatePrintMenuState,
 } from './app/file-actions';
 import { registerKeybindActions } from './app/keybinds';
+import { captureReadingSession, restoreReadingSession } from './app/session-state';
 import { restoreTabState, saveCurrentTabState } from './app/tab-state';
 import { setupTauriListeners } from './app/tauri-events';
 import {
@@ -110,6 +111,8 @@ const getInitialViewMode = (): 'single' | 'continuous' => {
 };
 
 let lastFilterSaveTimer: number | null = null;
+let sessionSaveTimer: number | null = null;
+let isRestoringSession = false;
 
 const scheduleLastFilterSave = (settings: FilterSettings): void => {
   const manager = settingsManager;
@@ -130,6 +133,68 @@ const scheduleLastFilterSave = (settings: FilterSettings): void => {
       lastFilterSaveTimer = null;
     }
   }, 250);
+};
+
+const saveReadingSessionNow = async (): Promise<void> => {
+  const manager = settingsManager;
+  if (!manager || !currentSettings?.general.restorePreviousSession || isRestoringSession) return;
+
+  saveCurrentTabState(tabManager, sliderManager);
+  const session = captureReadingSession(tabManager);
+  currentSettings = { ...currentSettings, lastSession: session };
+  await manager.set('lastSession', session);
+};
+
+const scheduleReadingSessionSave = (): void => {
+  if (!settingsManager || !currentSettings?.general.restorePreviousSession || isRestoringSession) {
+    return;
+  }
+
+  if (sessionSaveTimer !== null) {
+    clearTimeout(sessionSaveTimer);
+  }
+
+  sessionSaveTimer = window.setTimeout(async () => {
+    try {
+      await saveReadingSessionNow();
+    } catch (error) {
+      console.error('Failed to save reading session:', error);
+    } finally {
+      sessionSaveTimer = null;
+    }
+  }, 250);
+};
+
+const restorePreviousReadingSession = async (): Promise<number> => {
+  if (!tabManager || !currentSettings?.general.restorePreviousSession) return 0;
+
+  const session = currentSettings.lastSession;
+  if (!session?.tabs.length) return 0;
+
+  isRestoringSession = true;
+  try {
+    const result = await restoreReadingSession(session, {
+      tabManager,
+      sliderManager,
+      getInitialFilterSettings,
+      getInitialViewMode,
+    });
+
+    if (result.failed > 0) {
+      console.warn(`Skipped ${result.failed} PDF(s) while restoring the previous session.`);
+    }
+
+    if (result.opened > 0) {
+      updateTabBarVisibility(tabManager);
+      await updatePrintMenuState(tabManager);
+      await applyWindowAfterOpen();
+    }
+
+    return result.opened;
+  } finally {
+    isRestoringSession = false;
+    scheduleReadingSessionSave();
+  }
 };
 
 async function initializeApp(): Promise<void> {
@@ -157,11 +222,14 @@ async function initializeApp(): Promise<void> {
         updateTabBarVisibility(tabManager);
         // Update print menu state
         await updatePrintMenuState(tabManager);
+        scheduleReadingSessionSave();
       },
       () => {
         saveCurrentTabState(tabManager, sliderManager);
         updateUI(tabManager);
+        scheduleReadingSessionSave();
       },
+      scheduleReadingSessionSave,
     );
 
     // Initialize slider manager
@@ -175,6 +243,7 @@ async function initializeApp(): Promise<void> {
           // Save filter to tab state
           activeTab.filterSettings = filterSettings;
           scheduleLastFilterSave(filterSettings);
+          scheduleReadingSessionSave();
         }
       }
     });
@@ -183,7 +252,10 @@ async function initializeApp(): Promise<void> {
     keybindManager = new KeybindManager(isMac);
 
     const updateUIForTab = () => updateUI(tabManager);
-    const saveStateForTab = () => saveCurrentTabState(tabManager, sliderManager);
+    const saveStateForTab = () => {
+      saveCurrentTabState(tabManager, sliderManager);
+      scheduleReadingSessionSave();
+    };
     const updateTabBar = () => updateTabBarVisibility(tabManager);
 
     // Register all action handlers
@@ -233,6 +305,9 @@ async function initializeApp(): Promise<void> {
     // Update keyboard hints for platform
     updateKeyboardHints(isMac);
 
+    // Restore saved tabs before processing pending OS/CLI file-open events.
+    await restorePreviousReadingSession();
+
     // Listen for Tauri events
     await setupTauriListeners({
       tabManager,
@@ -253,6 +328,13 @@ async function initializeApp(): Promise<void> {
           clearTimeout(lastFilterSaveTimer);
           lastFilterSaveTimer = null;
         }
+        if (!updated.general.restorePreviousSession && sessionSaveTimer !== null) {
+          clearTimeout(sessionSaveTimer);
+          sessionSaveTimer = null;
+        }
+        if (updated.general.restorePreviousSession) {
+          scheduleReadingSessionSave();
+        }
       },
       applyWindowAfterOpen,
       updateTabBarVisibility: updateTabBar,
@@ -262,11 +344,19 @@ async function initializeApp(): Promise<void> {
       printCurrentPDF: () => printCurrentPDF(tabManager),
     });
 
-    // Show splash screen initially
-    showSplash();
+    // Show the correct initial surface after session/CLI restore has run.
+    if ((tabManager?.size ?? 0) > 0) {
+      showViewer();
+    } else {
+      showSplash();
+    }
 
     // Get current window
     const currentWindow = getCurrentWebviewWindow();
+
+    window.addEventListener('beforeunload', () => {
+      void saveReadingSessionNow();
+    });
 
     // Show window after initialization
     await currentWindow.show();

--- a/src/scripts/settings-page.ts
+++ b/src/scripts/settings-page.ts
@@ -58,6 +58,12 @@ async function loadSettings(): Promise<void> {
   const rememberLastFilter = document.getElementById('rememberLastFilter') as HTMLInputElement;
   if (rememberLastFilter) rememberLastFilter.checked = currentSettings.general.rememberLastFilter;
 
+  const restorePreviousSession = document.getElementById(
+    'restorePreviousSession',
+  ) as HTMLInputElement;
+  if (restorePreviousSession)
+    restorePreviousSession.checked = currentSettings.general.restorePreviousSession;
+
   const defaultContinuousScroll = document.getElementById(
     'defaultContinuousScroll',
   ) as HTMLInputElement;
@@ -126,6 +132,19 @@ function setupSettingListeners(): void {
   const rememberLastFilter = document.getElementById('rememberLastFilter') as HTMLInputElement;
   rememberLastFilter?.addEventListener('change', async () => {
     currentSettings.general.rememberLastFilter = rememberLastFilter.checked;
+    await settingsManager.set('general', currentSettings.general);
+    await notifyMainSettingsChanged();
+  });
+
+  const restorePreviousSession = document.getElementById(
+    'restorePreviousSession',
+  ) as HTMLInputElement;
+  restorePreviousSession?.addEventListener('change', async () => {
+    currentSettings.general.restorePreviousSession = restorePreviousSession.checked;
+    if (!restorePreviousSession.checked) {
+      currentSettings.lastSession = undefined;
+      await settingsManager.set('lastSession', undefined);
+    }
     await settingsManager.set('general', currentSettings.general);
     await notifyMainSettingsChanged();
   });

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -1,6 +1,21 @@
 import { Store } from '@tauri-apps/plugin-store';
 import type { FilterSettings } from './filters';
 
+export interface SavedTabSession {
+  filePath: string;
+  title: string;
+  filterSettings: FilterSettings;
+  currentPage: number;
+  zoom: number;
+  viewMode: 'single' | 'continuous';
+}
+
+export interface ReadingSession {
+  version: 1;
+  activeFilePath: string | null;
+  tabs: SavedTabSession[];
+}
+
 /**
  * Keybind configuration interface
  */
@@ -21,10 +36,12 @@ export interface MoonightSettings {
     displayThumbs: boolean;
     defaultDarkMode: string; // preset name
     rememberLastFilter: boolean;
+    restorePreviousSession: boolean;
     defaultViewMode: 'single' | 'continuous';
   };
   keybinds: Record<string, KeybindConfig>;
   lastFilter?: FilterSettings;
+  lastSession?: ReadingSession;
 }
 
 /**
@@ -37,6 +54,7 @@ export const DEFAULT_SETTINGS: MoonightSettings = {
     displayThumbs: true,
     defaultDarkMode: 'default',
     rememberLastFilter: true,
+    restorePreviousSession: true,
     defaultViewMode: 'continuous',
   },
   keybinds: {

--- a/src/scripts/tabs.ts
+++ b/src/scripts/tabs.ts
@@ -26,10 +26,16 @@ export class TabManager {
   private closedHistory: string[] = [];
   private onTabChange: (tab: TabData | null) => void;
   private onActiveViewerStateChange?: () => void;
+  private onTabsChanged?: () => void;
 
-  constructor(onTabChange: (tab: TabData | null) => void, onActiveViewerStateChange?: () => void) {
+  constructor(
+    onTabChange: (tab: TabData | null) => void,
+    onActiveViewerStateChange?: () => void,
+    onTabsChanged?: () => void,
+  ) {
     this.onTabChange = onTabChange;
     this.onActiveViewerStateChange = onActiveViewerStateChange;
+    this.onTabsChanged = onTabsChanged;
   }
 
   /**
@@ -80,6 +86,7 @@ export class TabManager {
 
     // Render tabs UI
     this.renderTabs();
+    this.onTabsChanged?.();
 
     // Activate the new tab (this will show its canvas)
     await this.activateTab(id);
@@ -123,6 +130,7 @@ export class TabManager {
 
     // Render tabs UI
     this.renderTabs();
+    this.onTabsChanged?.();
 
     console.log(`Closed tab: ${tab.title} (${id})`);
   }
@@ -157,6 +165,10 @@ export class TabManager {
   getActiveTab(): TabData | null {
     if (!this.activeTabId) return null;
     return this.tabs.get(this.activeTabId) || null;
+  }
+
+  getTabs(): TabData[] {
+    return Array.from(this.tabs.values());
   }
 
   /**


### PR DESCRIPTION
Add a Restore Previous Session setting that defaults on and reopens the reader's previous tab set on launch. A restored session includes open PDF paths, active document, current page, zoom level, filter settings, and view mode, matching the behavior expected from desktop PDF readers.

Persist sessions through the existing Tauri store-backed settings flow instead of storing document bytes. Session saves are debounced during normal navigation and tab changes, suppressed while startup restore is in progress, and flushed on unload where possible.

Introduce a small Reading Session domain term in CONTEXT.md and isolate capture/restore behavior in src/app/session-state.ts so settings remain storage-focused and TabManager only exposes the tab list needed for serialization.

Verification: npm run lint; npm run build; npm test; cargo test.