### PR TITLE
Fix reader regressions and preserve complete view state

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,17 @@ Monight is a cross-platform PDF reader built with Tauri and TypeScript. It combi
 Current version: `1.0.6`
 
 ## Features
+
 - Multi-tab PDF viewing
-- Adjustable zoom, fit-to-page/width, and rotation
+- Single-page, continuous-scroll, and two-page spread layouts
+- Adjustable zoom, fit-to-page/width, rotation, and cursor-anchored pinch/wheel zoom
+- Full-document text search (`Cmd/Ctrl+F`)
+- Table of contents and lazy-rendered page thumbnails
+- Persistent highlights and notes
+- Exact page and scroll-position restoration
+- Recent files on the launch screen
+- Password prompts for encrypted PDFs
+- Fullscreen presentation mode (`Shift+F11`)
 - Dark mode presets and a custom filter configurator
 - Customizable keyboard shortcuts
 - Native file dialogs and system menu integration
@@ -50,7 +59,10 @@ npm run dev
 ```
 
 ## Settings
-Settings are stored using the Tauri Store plugin and can be edited in the in-app Settings window. Options include default dark mode presets, remembering last filter, and keybind customization.
+Settings are stored using the Tauri Store plugin and can be edited in the in-app Settings
+window. Reading sessions, recent files, highlights, and notes are saved locally. Options include
+default dark mode presets, thumbnail visibility, session restoration, remembering the last
+filter, and keybind customization.
 
 ## Iconography
 The app icon is designed to follow Apple UI icon principles: minimal, bold silhouettes, and soft depth. The high-resolution source lives at `src-tauri/icons/icon-source.svg` and is used to generate the platform icon set.

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -1,0 +1,250 @@
+# Monight Code Review
+
+- **Date:** 2026-07-30
+- **Version reviewed:** 1.0.6
+- **Branch:** `develop` @ `9542969`
+- **Scope:** Full codebase (~7,900 LOC) — frontend viewer, app orchestration, Rust backend, config, packaging
+
+## Summary
+
+Monight is a Tauri 2 + TypeScript PDF reader. The architecture is genuinely good: pure logic
+is extracted into testable `src/lib/` modules (scroll geometry, output-scale capping,
+dimensions), `src/app/` cleanly separates orchestration concerns, the Rust side validates paths
+and URL schemes properly, and 43 tests pass. Recent commits show real engineering discipline —
+O(1) scroll geometry, lazy PDF engine loading, canvas area capping.
+
+The gaps are: a few live bugs, and a feature set that is thin for a daily-driver PDF reader.
+
+---
+
+## 1. Confirmed bugs
+
+Each item below was verified by reading the code and, where noted, by running it. Fix these first.
+
+### 1.1 `Cmd+1` through `Cmd+8` do nothing — tab switching is broken
+
+**Severity:** High — a shipped feature that silently does not work.
+
+`src/scripts/keybind-manager.ts:100-108` keys the lookup map by `config.action` rather than by
+the action ID:
+
+```ts
+const actionKey = config.action || actionId;   // 'switchToTab' for all nine entries
+this.keybinds.set(actionKey, parsed);          // each iteration overwrites the previous
+if (config.data) this.actionData.set(actionKey, config.data);
+```
+
+All nine `SwitchToTab*` entries in `src/scripts/settings.ts:151-204` share
+`action: 'switchToTab'`, so each `.set()` overwrites the last. Only `SwitchToTab9` survives.
+
+**Verified empirically** with a throwaway Vitest file run against the real `DEFAULT_SETTINGS`:
+
+```
+× Cmd+1 switches to tab 1     → AssertionError: expected null to be 'switchToTab'
+× Cmd+3 switches to tab 3     → AssertionError: expected null to be 'switchToTab'
+× surviving switchToTab binds → AssertionError: expected 1 to be 9
+✓ Cmd+9 works
+```
+
+`actionData` collides identically and ends as `'9'`, so even a repaired lookup map would route
+every tab shortcut to the last tab.
+
+**Fix:** key `keybinds` by `actionId`; store `action` and `data` per entry rather than using
+`action` as the map key.
+
+### 1.2 Drag-and-drop is completely dead
+
+**Severity:** High — an advertised feature that cannot fire.
+
+`src/app/tauri-events.ts:84,119,123` listen for Tauri **v1** event names:
+
+| Listened for (v1) | Actual Tauri 2 name |
+| --- | --- |
+| `tauri://file-drop` | `tauri://drag-drop` |
+| `tauri://file-drop-hover` | `tauri://drag-enter` |
+| `tauri://file-drop-cancelled` | `tauri://drag-leave` |
+
+Confirmed against `node_modules/@tauri-apps/api/event.d.ts:60-63`. The payload shape also
+changed — v2 sends `{ type, paths, position }`, not a bare `string[]`, so
+`event.payload.filter(...)` at `tauri-events.ts:88` would throw even if the event name matched.
+
+There is dead `body.drag-over` styling at `src/styles/main.css:139-148` that can never activate.
+
+**Fix:** use `getCurrentWebview().onDragDropEvent()`, which normalizes all four event types.
+
+### 1.3 Global keybinds hijack text inputs
+
+**Severity:** Medium — visible UX defect.
+
+`matchEvent` (`src/scripts/keybind-manager.ts:118`) has no check for whether focus is inside an
+editable element, and `src/app/dom-events.ts:174` calls `preventDefault()` on any match.
+
+Reproduction: click `#page-input`, press ArrowUp → jumps a page instead of incrementing the
+number. `Home` / `End` jump to first/last page instead of moving the caret.
+
+**Fix:** guard on `e.target` being `input` / `textarea` / `[contenteditable]`.
+
+### 1.4 Placeholder URLs ship to users
+
+**Severity:** Medium — user-visible, reputational.
+
+`src-tauri/src/menu.rs:224-242`:
+
+- Help → Learn More → `https://github.com/yourusername/yourrepo`
+- Help → License → `https://github.com/yourusername/yourrepo/blob/master/LICENSE`
+- Help → Report Bug → `https://github.com/yourusername/yourrepo/issues`
+- Help → Contact → `mailto:your-email@example.com`
+
+The actual remote is `https://github.com/ssword/Monight.git`. The License link also points at a
+file that does not exist (see §4).
+
+### 1.5 Cold open is O(n) in page count before first paint
+
+**Severity:** Medium — scales badly with document size.
+
+`src/scripts/pdf-viewer.ts:302-309` loops over **every page** calling `await getPage()` and
+`getViewport()` before rendering page 1:
+
+```ts
+for (let pageNum = 1; pageNum <= this.pdfDoc.numPages; pageNum++) {
+  const page = await this.pdfDoc.getPage(pageNum);
+  const viewport = page.getViewport({ scale: 1.0, rotation: 0 });
+  this.baseDimensions.set(pageNum, { width: viewport.width, height: viewport.height });
+}
+await this.renderPage(1);
+```
+
+On a 1,500-page document this is 1,500 sequential worker round-trips before anything appears on
+screen.
+
+**Fix:** compute page 1 immediately and render, then populate the dimension cache lazily or in a
+background pass. The cache already has a fallback path
+(`pdf-viewer.ts:1221-1230`) for entries that are missing, so partial population is safe.
+
+### 1.6 Rotation is silently lost; `scrollPosition` is a dead field
+
+**Severity:** Medium — contradicts the project's stated core purpose.
+
+- `TabData` (`src/scripts/tabs.ts:7-17`) has no `rotation` field, and `SavedTabSession`
+  (`src/scripts/settings.ts:4-11`) does not persist it. Rotate a page, restart the app, rotation
+  is gone. (`ViewState` at `pdf-viewer.ts:23-31` tracks it in memory, so it survives tab
+  switching within a session but not a restart.)
+- `TabData.scrollPosition` is declared at `tabs.ts:15` and initialized to `0` at `tabs.ts:63`,
+  and is **never read or written anywhere else** in the codebase.
+
+`CONTEXT.md` defines the project's central concept as preserving "each document's reading
+position and visual state." Restoring only a page number under-delivers on that.
+
+### 1.7 `Cmd+Shift+=` does not zoom in
+
+**Severity:** Low.
+
+`parseAccelerator` (`keybind-manager.ts:39-79`) turns `'CmdOrCtrl+Plus'`
+(`settings.ts:91-94`) into `key: 'plus'`, but `KeyboardEvent.key` is never the literal string
+`"plus"` — it is `'+'`. Verified: that bind matches `null`. The `'CmdOrCtrl+='` alias works, so
+zoom-in is reachable, but the documented `+` shortcut is not.
+
+### 1.8 `.fdf` / `.xdp` / `.xfdf` are registered file associations PDF.js cannot open
+
+**Severity:** Low-Medium — bad first-run experience via Finder/Explorer double-click.
+
+`src-tauri/tauri.conf.json` registers all four extensions as file associations.
+`read_pdf_bytes` (`src-tauri/src/commands.rs:65-76`) accepts them. `loadPDF`
+(`pdf-viewer.ts:291`) then hands the bytes to `getDocument()`, which cannot parse forms-data
+formats and throws a raw `InvalidPDFException` at the user.
+
+**Fix:** either drop the associations, or detect the format and show a meaningful message.
+
+---
+
+## 2. Functionality worth adding
+
+Ranked by user value per unit of effort.
+
+| Feature | Why | Effort |
+| --- | --- | --- |
+| **Text search (`Cmd+F`)** | The single biggest gap. Text layers already render, so the data is present. Non-negotiable for a PDF reader. | Medium |
+| **Outline / TOC sidebar** | `pdfDoc.getOutline()` plus the existing `resolveDestinationPage()` (`pdf-viewer.ts:486`) — most of the work is already written. | Small |
+| **Ctrl/Cmd+scroll & pinch zoom** | Zero wheel handlers exist anywhere in `src/`. Every PDF reader has this; its absence reads as broken. | Small |
+| **Page thumbnails sidebar** | `displayThumbs` is a live toggle in Settings (`settings.html:402-412`) labeled "(future feature)" that does nothing. | Medium |
+| **Precise scroll restore** | Finish what `scrollPosition` was meant to do — restore the exact offset, not the page top. Directly serves the stated project goal. | Small |
+| **Recent files on splash** | The splash is currently a logo and one button. | Small |
+| **Encrypted-PDF password prompt** | Password-protected PDFs currently fail with a raw error. | Small |
+| **Two-page / spread view** | Standard for books and papers. | Medium |
+| **Presentation mode** | Fullscreen, no chrome, arrow-key paging. | Small |
+| **Annotations & highlights** | The big differentiator, and the natural bridge to the AI features in the README roadmap. | Large |
+
+---
+
+## 3. Code health
+
+### 3.1 `pdf-viewer.ts` is 1,594 lines doing six jobs
+
+Rendering, continuous scroll, text layers, link layers, context menus, and printing all live in
+one class. `renderPage()` (`:734`) and `renderPageToContinuousCanvas()` (`:1370`) are roughly
+90% duplicated — identical `approximateFraction` → `floorToDivide` → outputScale → render
+sequence.
+
+**Suggested split:** extract one `renderToSurface(page, viewport, surface)` helper, then separate
+into `PdfRenderer` / `ContinuousScrollController` / `PageInteractionLayer`.
+
+### 3.2 Tests cover the safe parts, not the risky ones
+
+All 43 tests target pure `src/lib/` functions. There is zero coverage of `PDFViewer`,
+`TabManager`, or session restore — which is exactly where bugs 1.1, 1.2, 1.5, and 1.6 live. A
+single test asserting `Cmd+1 → switchToTab` would have caught 1.1.
+
+### 3.3 Smaller items
+
+- **12 `alert()` / `confirm()` calls** across `src/` block the UI thread and look non-native.
+  Replace with in-app toasts.
+- **48 `console.log` calls** ship to production. Gate behind `import.meta.env.DEV`.
+- **Zero `aria-` attributes** in `index.html`. Toolbar buttons are glyph-only (`◀`, `⬌`, `⊟`)
+  with no accessible names; there is no focus management.
+- **`withGlobalTauri: true`** (`src-tauri/tauri.conf.json`) exposes the full IPC surface on
+  `window`. Unnecessary — the app imports the API properly. Turn it off.
+- **Settings migration** keys off a string `version` field (`settings.ts:326-353`) that is bumped
+  every release, rewriting the store even when the schema did not change. A numeric
+  `schemaVersion` decoupled from the app version is more robust.
+- **`updateActivePresetButton`** (`src/app/ui.ts:42`) compares presets with `JSON.stringify` —
+  key-order dependent and fragile.
+
+---
+
+## 4. Release readiness
+
+- **No LICENSE file.** README says "TBD" and the Help menu links to a LICENSE that does not
+  exist. This blocks anyone from legally using or contributing to the project.
+- **No CI.** No `.github/` directory. Tests and lint exist but nothing runs them automatically.
+- **No auto-updater.** `tauri-plugin-updater` is absent from `src-tauri/Cargo.toml`. The app
+  ships DMG/MSI/deb/rpm/AppImage targets with no upgrade path.
+- **No code signing / notarization config.** Unsigned macOS builds are Gatekeeper-blocked.
+- **Window size and position are not persisted** across launches
+  (`tauri-plugin-window-state`), which contradicts the app's own "preserve reading state" thesis.
+- **No CHANGELOG.**
+- **`docs/performance-benchmarks.md`** is still an all-`pending` scaffold.
+
+---
+
+## 5. Suggested order of work
+
+1. **Bugs 1.1–1.4** — small diffs, all user-visible; two are shipped-broken features.
+2. **LICENSE + a GitHub Actions workflow** running `npm test`, `biome check`, and `cargo test`.
+3. **Bug 1.5** (O(n) cold open) and **bug 1.6** (persist rotation + scroll offset).
+4. **Text search, then outline sidebar** — the two features that most change daily usability.
+5. **Split `pdf-viewer.ts`** and add tests around `TabManager` and session restore.
+6. **Auto-updater + code signing** before any wider distribution.
+
+---
+
+## Appendix: verification notes
+
+- `npm test` → 8 files, 43 tests, all passing (136ms).
+- Bug 1.1 confirmed by a temporary Vitest file asserting `matchEvent` results against the real
+  `DEFAULT_SETTINGS`; the file was deleted after the run.
+- Bug 1.2 event names cross-checked against `node_modules/@tauri-apps/api/event.d.ts` and the
+  `DragDropEvent` type in `webview.d.ts:20-35`.
+- Absence of search / outline / thumbnails / wheel-zoom confirmed by grep across `src/`,
+  `index.html`, and `settings.html`.
+- Absence of LICENSE, CHANGELOG, `.github/`, and `tauri-plugin-updater` confirmed by direct
+  filesystem and manifest checks.

--- a/index.html
+++ b/index.html
@@ -20,6 +20,13 @@
             <p class="app-version" id="version-info">Loading...</p>
             <button id="splash-open-btn" class="splash-open-btn">Open PDF File</button>
             <p class="hint-text">Press Cmd+O to open a PDF file</p>
+            <section id="recent-files-section" class="recent-files hidden" aria-labelledby="recent-files-title">
+                <div class="recent-files-heading">
+                    <h3 id="recent-files-title">Recent files</h3>
+                    <button id="clear-recent-files" type="button">Clear</button>
+                </div>
+                <div id="recent-files-list" class="recent-files-list"></div>
+            </section>
         </div>
 
         <!-- PDF viewer container (hidden initially) -->
@@ -80,6 +87,24 @@
                     </button>
                 </div>
 
+                <div class="toolbar-group viewer-tools">
+                    <button id="open-search" class="toolbar-btn" title="Find in Document (Ctrl+F)" aria-label="Find in document">
+                        <span>⌕</span>
+                    </button>
+                    <button id="toggle-outline" class="toolbar-btn" title="Table of Contents" aria-label="Toggle table of contents">
+                        <span>☷</span>
+                    </button>
+                    <button id="toggle-thumbnails" class="toolbar-btn" title="Page Thumbnails" aria-label="Toggle page thumbnails">
+                        <span>▦</span>
+                    </button>
+                    <button id="toggle-annotations" class="toolbar-btn" title="Annotations" aria-label="Toggle annotations">
+                        <span>✎</span>
+                    </button>
+                    <button id="presentation-mode" class="toolbar-btn" title="Presentation Mode (Shift+F11)" aria-label="Start presentation mode">
+                        <span>▣</span>
+                    </button>
+                </div>
+
                 <!-- File info -->
                 <div class="toolbar-group file-info">
                     <span id="file-name" class="file-name">No file loaded</span>
@@ -96,6 +121,15 @@
                 </div>
             </div>
 
+            <div id="search-bar" class="search-bar hidden" role="search">
+                <label for="search-input">Find</label>
+                <input id="search-input" type="search" autocomplete="off" placeholder="Search this PDF" />
+                <span id="search-status" class="search-status" aria-live="polite">Type to search</span>
+                <button id="search-previous" type="button" title="Previous result (Shift+Enter)" aria-label="Previous search result">↑</button>
+                <button id="search-next" type="button" title="Next result (Enter)" aria-label="Next search result">↓</button>
+                <button id="search-close" type="button" title="Close search (Escape)" aria-label="Close search">✕</button>
+            </div>
+
             <!-- Tab Bar -->
             <div id="tab-bar" class="tab-bar hidden">
                 <div id="tab-container" class="tab-list">
@@ -104,8 +138,20 @@
                 <button id="new-tab-btn" class="new-tab-btn" title="Open New PDF (Ctrl+T)">+</button>
             </div>
 
-            <!-- PDF canvas container -->
-            <div id="pdf-container"></div>
+            <div id="document-workspace">
+                <aside id="document-sidebar" class="document-sidebar hidden" aria-label="Document sidebar">
+                    <div class="sidebar-tabs" role="tablist">
+                        <button type="button" data-sidebar-tab="outline" role="tab">Contents</button>
+                        <button id="thumbnails-tab" type="button" data-sidebar-tab="thumbnails" role="tab">Pages</button>
+                        <button type="button" data-sidebar-tab="annotations" role="tab">Notes</button>
+                        <button id="close-sidebar" type="button" class="sidebar-close" title="Close sidebar" aria-label="Close sidebar">✕</button>
+                    </div>
+                    <div id="sidebar-content" class="sidebar-content"></div>
+                </aside>
+
+                <!-- PDF canvas container -->
+                <div id="pdf-container"></div>
+            </div>
         </div>
 
         <!-- Dark Mode Configurator Overlay -->
@@ -143,6 +189,37 @@
                 </div>
             </div>
         </div>
+
+        <dialog id="password-dialog" class="app-dialog">
+            <form method="dialog">
+                <h2 data-password-title>Unlock PDF</h2>
+                <p data-password-message>This PDF is encrypted.</p>
+                <label>
+                    Password
+                    <input name="password" type="password" autocomplete="off" required />
+                </label>
+                <div class="dialog-actions">
+                    <button type="button" class="dialog-secondary" data-dialog-cancel>Cancel</button>
+                    <button type="submit" class="dialog-primary">Unlock</button>
+                </div>
+            </form>
+        </dialog>
+
+        <dialog id="annotation-dialog" class="app-dialog">
+            <form method="dialog">
+                <h2>Annotation note</h2>
+                <label>
+                    Note
+                    <textarea name="note" rows="5" placeholder="Add a note to this highlight"></textarea>
+                </label>
+                <div class="dialog-actions">
+                    <button type="button" class="dialog-secondary" data-dialog-cancel>Cancel</button>
+                    <button type="submit" class="dialog-primary">Save</button>
+                </div>
+            </form>
+        </dialog>
+
+        <div id="toast-region" class="toast-region" aria-live="polite"></div>
     </div>
     <script type="module" src="/src/main.ts"></script>
 </body>

--- a/settings.html
+++ b/settings.html
@@ -402,7 +402,7 @@
                 <div class="setting-item">
                     <div class="setting-label">
                         <h3>Display Thumbnails</h3>
-                        <p>Show page thumbnails in sidebar (future feature)</p>
+                        <p>Show the page thumbnails tab in the document sidebar</p>
                     </div>
                     <div class="setting-control">
                         <label class="toggle-switch">

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -70,7 +70,7 @@ pub(crate) fn read_pdf_bytes(path: String) -> Result<Vec<u8>, String> {
             format!(".{}", ext)
         };
         return Err(format!(
-            "Unsupported file type {}. Only PDF, XDP, FDF, and XFDF files are supported.",
+            "Unsupported file type {}. Only PDF files are supported.",
             ext_label
         ));
     }
@@ -259,7 +259,7 @@ pub fn validate_open_path(path: String) -> Result<String, String> {
             format!(".{}", ext)
         };
         return Err(format!(
-            "Unsupported file type {}. Only PDF, XDP, FDF, and XFDF files are supported.",
+            "Unsupported file type {}. Only PDF files are supported.",
             ext_label
         ));
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,12 +36,7 @@ pub struct PendingCliPayload(pub Mutex<Option<CliPayload>>);
 pub(crate) fn is_supported_extension(path: &std::path::Path) -> bool {
     path.extension()
         .and_then(|e| e.to_str())
-        .map(|ext| {
-            matches!(
-                ext.to_ascii_lowercase().as_str(),
-                "pdf" | "xdp" | "fdf" | "xfdf"
-            )
-        })
+        .map(|ext| ext.eq_ignore_ascii_case("pdf"))
         .unwrap_or(false)
 }
 
@@ -200,7 +195,7 @@ pub fn run() {
                     println!("Opening files from CLI: {:?}", payload.files);
 
                     // Store and emit event (frontend will also pull pending on ready)
-                    dispatch_open_payload(&app_handle, payload);
+                    dispatch_open_payload(app_handle, payload);
                 }
             }
 
@@ -301,5 +296,35 @@ mod tests {
 
         assert_eq!(payload.files, vec![fixture.to_string_lossy().to_string()]);
         assert_eq!(payload.page, None);
+    }
+
+    #[test]
+    fn test_only_pdf_is_a_supported_document_extension() {
+        assert!(is_supported_extension(std::path::Path::new("report.pdf")));
+        assert!(is_supported_extension(std::path::Path::new("REPORT.PDF")));
+        assert!(!is_supported_extension(std::path::Path::new("form.xdp")));
+        assert!(!is_supported_extension(std::path::Path::new("form.fdf")));
+        assert!(!is_supported_extension(std::path::Path::new("form.xfdf")));
+    }
+
+    #[test]
+    fn test_bundle_only_registers_pdf_file_associations() {
+        let config: serde_json::Value =
+            serde_json::from_str(include_str!("../tauri.conf.json")).expect("valid Tauri config");
+        let associations = config["bundle"]["fileAssociations"]
+            .as_array()
+            .expect("file associations should be an array");
+        let extensions = associations
+            .iter()
+            .flat_map(|association| {
+                association["ext"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(serde_json::Value::as_str)
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(extensions, vec!["pdf"]);
     }
 }

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -6,7 +6,6 @@ use tauri::{
 // Import for opening URLs in browser
 use tauri_plugin_opener::OpenerExt;
 
-
 fn build_file_menu(app: &AppHandle) -> Result<Submenu<Wry>, tauri::Error> {
     Submenu::with_items(
         app,
@@ -35,7 +34,13 @@ fn build_file_menu_with_settings(
             &MenuItem::with_id(app, "open", "Open...", true, Some("CmdOrCtrl+O"))?,
             &MenuItem::with_id(app, "print", "Print", true, Some("CmdOrCtrl+P"))?,
             &PredefinedMenuItem::separator(app)?,
-            &MenuItem::with_id(app, "settings", settings_label, true, Some(settings_shortcut))?,
+            &MenuItem::with_id(
+                app,
+                "settings",
+                settings_label,
+                true,
+                Some(settings_shortcut),
+            )?,
             &PredefinedMenuItem::separator(app)?,
             &PredefinedMenuItem::close_window(app, Some("Close"))?,
         ],
@@ -136,6 +141,16 @@ fn emit_to_main(app: &AppHandle, event: &str) {
     }
 }
 
+fn help_url(event_id: &str) -> Option<&'static str> {
+    match event_id {
+        "learn_more" => Some("https://github.com/ssword/Monight"),
+        "license" => Some("https://github.com/ssword/Monight#license"),
+        "bugs" => Some("https://github.com/ssword/Monight/issues/new"),
+        "contact" => Some("https://github.com/ssword"),
+        _ => None,
+    }
+}
+
 /// Create the application menu
 pub fn create_menu(app: &AppHandle) -> Result<Menu<Wry>, tauri::Error> {
     // Create menu with platform-specific Settings placement
@@ -219,28 +234,33 @@ pub fn handle_menu_event(app: &AppHandle, event_id: &str) {
         "close_tab" => {
             emit_to_main(app, "menu-close-tab");
         }
-        "learn_more" => {
-            // Open GitHub repo in browser (placeholder URL)
-            let _ = app.opener().open_url("https://github.com/yourusername/yourrepo", None::<&str>);
-        }
-        "license" => {
-            // Open LICENSE file in browser (placeholder URL)
-            let _ = app.opener().open_url(
-                "https://github.com/yourusername/yourrepo/blob/master/LICENSE",
-                None::<&str>,
-            );
-        }
-        "bugs" => {
-            // Open GitHub issues in browser (placeholder URL)
-            let _ = app.opener().open_url(
-                "https://github.com/yourusername/yourrepo/issues",
-                None::<&str>,
-            );
-        }
-        "contact" => {
-            // Open email client (placeholder email)
-            let _ = app.opener().open_url("mailto:your-email@example.com", None::<&str>);
+        "learn_more" | "license" | "bugs" | "contact" => {
+            if let Some(url) = help_url(event_id) {
+                let _ = app.opener().open_url(url, None::<&str>);
+            }
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn help_destinations_use_the_real_project_pages() {
+        assert_eq!(
+            help_url("learn_more"),
+            Some("https://github.com/ssword/Monight")
+        );
+        assert_eq!(
+            help_url("license"),
+            Some("https://github.com/ssword/Monight#license")
+        );
+        assert_eq!(
+            help_url("bugs"),
+            Some("https://github.com/ssword/Monight/issues/new")
+        );
+        assert_eq!(help_url("contact"), Some("https://github.com/ssword"));
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,27 +50,6 @@
         "description": "Portable Document Format",
         "role": "Viewer",
         "mimeType": "application/pdf"
-      },
-      {
-        "ext": ["xdp"],
-        "name": "XFA Document",
-        "description": "XML Forms Architecture",
-        "role": "Viewer",
-        "mimeType": "application/vnd.adobe.xdp+xml"
-      },
-      {
-        "ext": ["fdf"],
-        "name": "FDF Document",
-        "description": "Forms Data Format",
-        "role": "Viewer",
-        "mimeType": "application/vnd.fdf"
-      },
-      {
-        "ext": ["xfdf"],
-        "name": "XFDF Document",
-        "description": "XML Forms Data Format",
-        "role": "Viewer",
-        "mimeType": "application/vnd.adobe.xfdf"
       }
     ],
     "targets": ["deb", "rpm", "appimage", "dmg", "nsis", "msi"]

--- a/src/__tests__/document-features.test.ts
+++ b/src/__tests__/document-features.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { findPageTextMatches, nextViewMode, updateRecentFiles } from '../lib/document-features';
+
+describe('document features', () => {
+  it('cycles through single, continuous, and spread layouts', () => {
+    expect(nextViewMode('single')).toBe('continuous');
+    expect(nextViewMode('continuous')).toBe('spread');
+    expect(nextViewMode('spread')).toBe('single');
+  });
+
+  it('finds every non-overlapping case-insensitive page match', () => {
+    expect(findPageTextMatches('Moon light, moon night.', 'MOON', 4)).toEqual([
+      expect.objectContaining({ pageNumber: 4, pageOccurrence: 0, index: 0 }),
+      expect.objectContaining({ pageNumber: 4, pageOccurrence: 1, index: 12 }),
+    ]);
+  });
+
+  it('moves an opened file to the front and keeps the list bounded', () => {
+    const recent = [
+      { filePath: '/a.pdf', title: 'a.pdf', openedAt: 1 },
+      { filePath: '/b.pdf', title: 'b.pdf', openedAt: 2 },
+    ];
+
+    expect(
+      updateRecentFiles(recent, { filePath: '/b.pdf', title: 'B.pdf', openedAt: 3 }, 2),
+    ).toEqual([
+      { filePath: '/b.pdf', title: 'B.pdf', openedAt: 3 },
+      { filePath: '/a.pdf', title: 'a.pdf', openedAt: 1 },
+    ]);
+  });
+});

--- a/src/__tests__/keybind-manager.test.ts
+++ b/src/__tests__/keybind-manager.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import { KeybindManager } from '../scripts/keybind-manager';
+import { DEFAULT_SETTINGS } from '../scripts/settings';
+
+function keyboardEvent(
+  key: string,
+  {
+    metaKey = true,
+    shiftKey = false,
+    target = null,
+  }: {
+    metaKey?: boolean;
+    shiftKey?: boolean;
+    target?: EventTarget | null;
+  } = {},
+): KeyboardEvent {
+  return {
+    key,
+    ctrlKey: false,
+    metaKey,
+    shiftKey,
+    altKey: false,
+    target,
+  } as KeyboardEvent;
+}
+
+describe('KeybindManager', () => {
+  it('keeps every configured tab shortcut and routes its own tab position', async () => {
+    const manager = new KeybindManager(true);
+    const switchToTab = vi.fn();
+    manager.registerAction('switchToTab', switchToTab);
+    manager.loadFromSettings(DEFAULT_SETTINGS);
+
+    const configuredTabBindings = Array.from(manager.getAllKeybinds().keys()).filter((actionId) =>
+      actionId.startsWith('SwitchToTab'),
+    );
+    expect(configuredTabBindings).toHaveLength(9);
+
+    const firstEvent = keyboardEvent('1');
+    const eighthEvent = keyboardEvent('8');
+    expect(manager.matchEvent(firstEvent)).toBe('switchToTab');
+    expect(manager.matchEvent(eighthEvent)).toBe('switchToTab');
+
+    await manager.handleEvent(firstEvent);
+    await manager.handleEvent(eighthEvent);
+
+    expect(switchToTab).toHaveBeenNthCalledWith(1, firstEvent, '1');
+    expect(switchToTab).toHaveBeenNthCalledWith(2, eighthEvent, '8');
+  });
+
+  it('does not match global shortcuts from editable controls', () => {
+    const manager = new KeybindManager(true);
+    manager.loadFromSettings(DEFAULT_SETTINGS);
+
+    expect(
+      manager.matchEvent(
+        keyboardEvent('ArrowUp', {
+          metaKey: false,
+          target: { tagName: 'INPUT' } as unknown as EventTarget,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      manager.matchEvent(
+        keyboardEvent('Home', {
+          metaKey: false,
+          target: { tagName: 'TEXTAREA' } as unknown as EventTarget,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      manager.matchEvent(
+        keyboardEvent('End', {
+          metaKey: false,
+          target: { isContentEditable: true } as unknown as EventTarget,
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('matches Cmd+Shift+= as the configured Plus accelerator', () => {
+    const manager = new KeybindManager(true);
+    manager.loadFromSettings(DEFAULT_SETTINGS);
+
+    expect(manager.matchEvent(keyboardEvent('+', { shiftKey: true }))).toBe('zoomIn');
+  });
+});

--- a/src/__tests__/pdf-viewer-load.test.ts
+++ b/src/__tests__/pdf-viewer-load.test.ts
@@ -38,6 +38,12 @@ describe('PDFViewer initial load', () => {
         viewMode: 'single',
       },
       baseDimensions: new Map(),
+      pageTextCache: new Map(),
+      pageSurfaces: new Map(),
+      singlePageSurface: null,
+      searchQuery: '',
+      searchMatches: [],
+      activeSearchMatch: null,
     });
     vi.spyOn(viewer, 'renderPage').mockImplementation(async (pageNumber: number) => {
       events.push(`render:${pageNumber}`);
@@ -46,5 +52,253 @@ describe('PDFViewer initial load', () => {
     await viewer.loadPDF(new Uint8Array([1]), 'report.pdf', '/tmp/report.pdf');
 
     expect(events[0]).toBe('render:1');
+  });
+
+  it('requests and applies an encrypted-document password', async () => {
+    vi.stubGlobal('document', {
+      createElement: () => ({ style: { width: '' } }),
+    });
+
+    let resolveDocument: (document: { numPages: number }) => void = () => {};
+    const loadingTask = {
+      onPassword: undefined as
+        | ((updatePassword: (password: string) => void, reason: number) => void)
+        | undefined,
+      promise: new Promise<{ numPages: number }>((resolve) => {
+        resolveDocument = resolve;
+      }),
+      destroy: vi.fn(async () => {}),
+    };
+    getPdfEngine.mockResolvedValue({
+      PasswordResponses: { NEED_PASSWORD: 1, INCORRECT_PASSWORD: 2 },
+      getDocument: () => loadingTask,
+    });
+
+    const { PDFViewer } = await import('../scripts/pdf-viewer');
+    const viewer = Object.create(PDFViewer.prototype) as InstanceType<typeof PDFViewer>;
+    const requestPassword = vi.fn(async () => 'open-sesame');
+    Object.assign(viewer, {
+      renderTask: null,
+      requestPassword,
+      state: {
+        currentPage: 1,
+        totalPages: 0,
+        zoom: 1,
+        rotation: 0,
+        fileName: '',
+        filePath: '',
+        viewMode: 'single',
+      },
+      baseDimensions: new Map(),
+      pageTextCache: new Map(),
+      pageSurfaces: new Map(),
+      singlePageSurface: null,
+      searchQuery: '',
+      searchMatches: [],
+      activeSearchMatch: null,
+    });
+    vi.spyOn(viewer, 'renderPage').mockResolvedValue();
+
+    const loadPromise = viewer.loadPDF(new Uint8Array([1]), 'protected.pdf', '/tmp/protected.pdf');
+    await vi.waitFor(() => expect(loadingTask.onPassword).toBeTypeOf('function'));
+    const updatePassword = vi.fn();
+    loadingTask.onPassword?.(updatePassword, 2);
+    await vi.waitFor(() => expect(updatePassword).toHaveBeenCalledWith('open-sesame'));
+    expect(requestPassword).toHaveBeenCalledWith('protected.pdf', 'incorrect');
+
+    resolveDocument({ numPages: 1 });
+    await loadPromise;
+  });
+
+  it('searches cached PDF text and resolves outline destinations', async () => {
+    vi.stubGlobal('document', {
+      createElement: () => ({ style: { width: '' } }),
+    });
+    const { PDFViewer } = await import('../scripts/pdf-viewer');
+    const viewer = Object.create(PDFViewer.prototype) as InstanceType<typeof PDFViewer>;
+    const getPage = vi.fn(async (pageNumber: number) => ({
+      getTextContent: async () => ({
+        items: [{ str: pageNumber === 1 ? 'Moon light moon' : 'Night sky' }],
+      }),
+    }));
+    Object.assign(viewer, {
+      state: {
+        currentPage: 1,
+        totalPages: 2,
+        zoom: 1,
+        rotation: 0,
+        fileName: 'book.pdf',
+        filePath: '/tmp/book.pdf',
+        viewMode: 'single',
+      },
+      pdfDoc: {
+        getPage,
+        getOutline: async () => [
+          {
+            title: 'Second page',
+            bold: false,
+            italic: false,
+            dest: [1],
+            url: null,
+            items: [],
+          },
+        ],
+      },
+      pageTextCache: new Map(),
+      pageSurfaces: new Map(),
+      singlePageSurface: null,
+      searchQuery: '',
+      searchMatches: [],
+      activeSearchMatch: null,
+    });
+
+    const matches = await viewer.searchText('moon');
+    expect(matches).toHaveLength(2);
+    expect(matches.map((match) => match.pageOccurrence)).toEqual([0, 1]);
+    await expect(viewer.getOutlineItems()).resolves.toEqual([
+      expect.objectContaining({ title: 'Second page', pageNumber: 2 }),
+    ]);
+  });
+
+  it('advances two pages at a time in spread view', async () => {
+    vi.stubGlobal('document', {
+      createElement: () => ({ style: { width: '' } }),
+    });
+    const { PDFViewer } = await import('../scripts/pdf-viewer');
+    const viewer = Object.create(PDFViewer.prototype) as InstanceType<typeof PDFViewer>;
+    Object.assign(viewer, {
+      state: {
+        currentPage: 3,
+        totalPages: 8,
+        zoom: 1,
+        rotation: 0,
+        fileName: 'book.pdf',
+        filePath: '/tmp/book.pdf',
+        viewMode: 'spread',
+      },
+    });
+    const goToPage = vi.spyOn(viewer, 'goToPage').mockResolvedValue();
+
+    await viewer.nextPage();
+    expect(goToPage).toHaveBeenCalledWith(5);
+  });
+
+  it('includes both spread pages in interactive-layer refreshes', async () => {
+    vi.stubGlobal('document', {
+      createElement: () => ({ style: { width: '' } }),
+    });
+    const { PDFViewer } = await import('../scripts/pdf-viewer');
+    const viewer = Object.create(PDFViewer.prototype) as InstanceType<typeof PDFViewer>;
+    const continuousSurface = { pageNumber: 3 };
+    const primarySurface = { pageNumber: 5 };
+    const companionSurface = { pageNumber: 6 };
+    Object.assign(viewer, {
+      pageSurfaces: new Map([[3, continuousSurface]]),
+      singlePageSurface: primarySurface,
+      spreadPageSurface: companionSurface,
+    });
+
+    const surfaces = (
+      viewer as unknown as {
+        getPageSurfaces: () => unknown[];
+      }
+    ).getPageSurfaces();
+
+    expect(surfaces).toEqual([continuousSurface, primarySurface, companionSurface]);
+  });
+
+  it('turns modified wheel input and pinch gestures into anchored zoom', async () => {
+    vi.stubGlobal('document', {
+      createElement: () => ({ style: { width: '' } }),
+    });
+    vi.stubGlobal('window', {
+      requestAnimationFrame: (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      },
+    });
+    const { PDFViewer } = await import('../scripts/pdf-viewer');
+    const viewer = Object.create(PDFViewer.prototype) as InstanceType<typeof PDFViewer>;
+    const zoomAtPoint = vi.fn(async () => {});
+    Object.assign(viewer, {
+      state: {
+        currentPage: 1,
+        totalPages: 1,
+        zoom: 2,
+        rotation: 0,
+        fileName: 'book.pdf',
+        filePath: '/tmp/book.pdf',
+        viewMode: 'single',
+      },
+      container: {
+        getBoundingClientRect: () => ({ left: 0, top: 0, width: 800, height: 600 }),
+      },
+      pendingWheelDelta: 0,
+      wheelZoomRafId: null,
+      pinchStartZoom: 2,
+      zoomAtPoint,
+    });
+    const privateViewer = viewer as unknown as {
+      handleWheel: (event: WheelEvent) => void;
+      handleGestureStart: (event: Event) => void;
+      handleGestureChange: (event: Event & { scale: number }) => void;
+    };
+    const preventDefault = vi.fn();
+
+    privateViewer.handleWheel({
+      ctrlKey: true,
+      metaKey: false,
+      deltaY: -100,
+      clientX: 120,
+      clientY: 180,
+      preventDefault,
+    } as unknown as WheelEvent);
+    expect(preventDefault).toHaveBeenCalled();
+    expect(zoomAtPoint).toHaveBeenCalledWith(expect.any(Number), 120, 180);
+
+    privateViewer.handleGestureStart({ preventDefault } as unknown as Event);
+    privateViewer.handleGestureChange({
+      scale: 1.5,
+      preventDefault,
+    } as unknown as Event & { scale: number });
+    expect(zoomAtPoint).toHaveBeenLastCalledWith(3, 400, 300);
+  });
+
+  it('updates annotation notes and emits a persistence snapshot', async () => {
+    vi.stubGlobal('document', {
+      createElement: () => ({ style: { width: '' } }),
+    });
+    const { PDFViewer } = await import('../scripts/pdf-viewer');
+    const viewer = Object.create(PDFViewer.prototype) as InstanceType<typeof PDFViewer>;
+    const onAnnotationsChange = vi.fn();
+    Object.assign(viewer, {
+      annotations: [
+        {
+          id: 'note-1',
+          kind: 'highlight',
+          pageNumber: 2,
+          rects: [{ x1: 1, y1: 2, x2: 3, y2: 4 }],
+          text: 'selected text',
+          note: '',
+          color: 'yellow',
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      pageSurfaces: new Map(),
+      singlePageSurface: null,
+      spreadPageSurface: null,
+      onAnnotationsChange,
+    });
+
+    viewer.updateAnnotation('note-1', { note: 'Remember this', color: 'blue' });
+
+    expect(viewer.getAnnotations()[0]).toMatchObject({
+      note: 'Remember this',
+      color: 'blue',
+    });
+    expect(onAnnotationsChange).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'note-1', note: 'Remember this' }),
+    ]);
   });
 });

--- a/src/__tests__/pdf-viewer-load.test.ts
+++ b/src/__tests__/pdf-viewer-load.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const getPdfEngine = vi.hoisted(() => vi.fn());
+
+vi.mock('../lib/pdf-engine', () => ({ getPdfEngine }));
+
+describe('PDFViewer initial load', () => {
+  it('renders page one before requesting dimensions for the remaining pages', async () => {
+    vi.stubGlobal('document', {
+      createElement: () => ({ style: { width: '' } }),
+    });
+
+    const events: string[] = [];
+    const pdfDocument = {
+      numPages: 3,
+      getPage: vi.fn(async (pageNumber: number) => {
+        events.push(`dimensions:${pageNumber}`);
+        return {
+          getViewport: () => ({ width: 600, height: 800 }),
+        };
+      }),
+    };
+    getPdfEngine.mockResolvedValue({
+      getDocument: () => ({ promise: Promise.resolve(pdfDocument) }),
+    });
+
+    const { PDFViewer } = await import('../scripts/pdf-viewer');
+    const viewer = Object.create(PDFViewer.prototype) as InstanceType<typeof PDFViewer>;
+    Object.assign(viewer, {
+      renderTask: null,
+      state: {
+        currentPage: 1,
+        totalPages: 0,
+        zoom: 1,
+        rotation: 0,
+        fileName: '',
+        filePath: '',
+        viewMode: 'single',
+      },
+      baseDimensions: new Map(),
+    });
+    vi.spyOn(viewer, 'renderPage').mockImplementation(async (pageNumber: number) => {
+      events.push(`render:${pageNumber}`);
+    });
+
+    await viewer.loadPDF(new Uint8Array([1]), 'report.pdf', '/tmp/report.pdf');
+
+    expect(events[0]).toBe('render:1');
+  });
+});

--- a/src/__tests__/presentation-controller.test.ts
+++ b/src/__tests__/presentation-controller.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const currentWindow = vi.hoisted(() => ({
+  isFullscreen: vi.fn(async () => false),
+  setFullscreen: vi.fn(async () => {}),
+}));
+
+vi.mock('@tauri-apps/api/webviewWindow', () => ({
+  getCurrentWebviewWindow: () => currentWindow,
+}));
+
+describe('PresentationController', () => {
+  beforeEach(() => {
+    currentWindow.isFullscreen.mockClear();
+    currentWindow.setFullscreen.mockClear();
+
+    const bodyClasses = new Set<string>();
+    vi.stubGlobal('document', {
+      body: {
+        classList: {
+          add: (className: string) => bodyClasses.add(className),
+          remove: (className: string) => bodyClasses.delete(className),
+          contains: (className: string) => bodyClasses.has(className),
+        },
+      },
+      getElementById: () => ({
+        addEventListener: vi.fn(),
+      }),
+      addEventListener: vi.fn(),
+    });
+    vi.stubGlobal('window', {
+      requestAnimationFrame: (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      },
+    });
+  });
+
+  it('enters fullscreen single-page mode and restores the previous view', async () => {
+    const { PresentationController } = await import('../app/presentation-controller');
+    const viewer = {
+      getState: () => ({ viewMode: 'spread' as const, zoom: 1.75 }),
+      setViewMode: vi.fn(async () => {}),
+      fitToPage: vi.fn(async () => {}),
+      setZoom: vi.fn(async () => {}),
+    };
+    const onStateChanged = vi.fn();
+    const controller = new PresentationController({
+      getActiveViewer: () => viewer as never,
+      onStateChanged,
+    });
+
+    await controller.enter();
+
+    expect(controller.isActive()).toBe(true);
+    expect(document.body.classList.contains('presentation-mode')).toBe(true);
+    expect(currentWindow.setFullscreen).toHaveBeenCalledWith(true);
+    expect(viewer.setViewMode).toHaveBeenCalledWith('single');
+    expect(viewer.fitToPage).toHaveBeenCalled();
+
+    await controller.exit();
+
+    expect(controller.isActive()).toBe(false);
+    expect(document.body.classList.contains('presentation-mode')).toBe(false);
+    expect(currentWindow.setFullscreen).toHaveBeenLastCalledWith(false);
+    expect(viewer.setViewMode).toHaveBeenLastCalledWith('spread');
+    expect(viewer.setZoom).toHaveBeenCalledWith(1.75);
+    expect(onStateChanged).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/session-state.test.ts
+++ b/src/__tests__/session-state.test.ts
@@ -20,6 +20,7 @@ function savedTab(): TabData {
     rotation: 270,
     scrollPosition: 4321,
     viewMode: 'continuous',
+    annotations: [],
   };
 }
 

--- a/src/__tests__/session-state.test.ts
+++ b/src/__tests__/session-state.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { captureReadingSession } from '../app/session-state';
+import { restoreTabState, saveCurrentTabState } from '../app/tab-state';
+import { PRESETS } from '../scripts/filters';
+import type { TabData, TabManager } from '../scripts/tabs';
+
+vi.mock('../app/ui', () => ({
+  updateActivePresetButton: vi.fn(),
+}));
+
+function savedTab(): TabData {
+  return {
+    id: 'tab-1',
+    title: 'report.pdf',
+    filePath: '/tmp/report.pdf',
+    pdfData: new Uint8Array(),
+    filterSettings: { ...PRESETS.default },
+    currentPage: 12,
+    zoom: 1.75,
+    rotation: 270,
+    scrollPosition: 4321,
+    viewMode: 'continuous',
+  };
+}
+
+describe('reading session visual state', () => {
+  beforeEach(() => {
+    vi.stubGlobal('document', {
+      getElementById: vi.fn(() => null),
+    });
+  });
+
+  it('captures rotation and exact scroll position', () => {
+    const tab = savedTab();
+    const tabManager = {
+      getActiveTab: () => tab,
+      getTabs: () => [tab],
+    } as unknown as TabManager;
+
+    expect(captureReadingSession(tabManager).tabs[0]).toMatchObject({
+      rotation: 270,
+      scrollPosition: 4321,
+    });
+  });
+
+  it('copies rotation and exact scroll position from the viewer into the active tab', () => {
+    const tab = savedTab();
+    tab.rotation = 0;
+    tab.scrollPosition = 0;
+
+    const viewer = {
+      getState: () => ({
+        currentPage: 7,
+        totalPages: 20,
+        zoom: 2,
+        rotation: 90,
+        fileName: tab.title,
+        filePath: tab.filePath,
+        viewMode: 'continuous' as const,
+      }),
+      getScrollPosition: () => 987,
+    };
+    const tabManager = {
+      getActiveTab: () => tab,
+      getViewerForTab: () => viewer,
+    } as unknown as TabManager;
+
+    saveCurrentTabState(tabManager, null);
+
+    expect(tab).toMatchObject({
+      currentPage: 7,
+      zoom: 2,
+      rotation: 90,
+      scrollPosition: 987,
+      viewMode: 'continuous',
+    });
+  });
+
+  it('restores geometry before the page and exact scroll position', async () => {
+    const calls: string[] = [];
+    const viewer = {
+      setRotation: vi.fn(async (rotation: number) => {
+        calls.push(`rotation:${rotation}`);
+      }),
+      setZoom: vi.fn(async (zoom: number) => {
+        calls.push(`zoom:${zoom}`);
+      }),
+      setViewMode: vi.fn(async (viewMode: string) => {
+        calls.push(`viewMode:${viewMode}`);
+      }),
+      goToPage: vi.fn(async (page: number) => {
+        calls.push(`page:${page}`);
+      }),
+      setScrollPosition: vi.fn(async (scrollPosition: number) => {
+        calls.push(`scroll:${scrollPosition}`);
+      }),
+      applyFilter: vi.fn(),
+    };
+    const tab = savedTab();
+    const tabManager = {
+      getViewerForTab: () => viewer,
+    } as unknown as TabManager;
+
+    await restoreTabState(tabManager, null, tab);
+
+    expect(calls).toEqual([
+      'rotation:270',
+      'zoom:1.75',
+      'viewMode:continuous',
+      'page:12',
+      'scroll:4321',
+    ]);
+  });
+});

--- a/src/__tests__/tauri-events.test.ts
+++ b/src/__tests__/tauri-events.test.ts
@@ -1,0 +1,109 @@
+import type { DragDropEvent } from '@tauri-apps/api/webview';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PRESETS } from '../scripts/filters';
+import type { TabManager } from '../scripts/tabs';
+
+const mocks = vi.hoisted(() => {
+  let dragDropHandler: ((event: { payload: DragDropEvent }) => void | Promise<void>) | undefined;
+
+  return {
+    invoke: vi.fn(async () => null),
+    listen: vi.fn(async () => vi.fn()),
+    openFiles: vi.fn(async () => 1),
+    onDragDropEvent: vi.fn(
+      async (handler: (event: { payload: DragDropEvent }) => void | Promise<void>) => {
+        dragDropHandler = handler;
+        return vi.fn();
+      },
+    ),
+    getDragDropHandler: () => dragDropHandler,
+    resetDragDropHandler: () => {
+      dragDropHandler = undefined;
+    },
+  };
+});
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: mocks.invoke }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: mocks.listen }));
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({ onDragDropEvent: mocks.onDragDropEvent }),
+}));
+vi.mock('@tauri-apps/api/webviewWindow', () => ({
+  getCurrentWebviewWindow: () => ({
+    isFullscreen: vi.fn(async () => false),
+    setFullscreen: vi.fn(async () => undefined),
+  }),
+}));
+vi.mock('../app/file-actions', () => ({ openFiles: mocks.openFiles }));
+
+import { setupTauriListeners } from '../app/tauri-events';
+
+describe('Tauri drag and drop events', () => {
+  const addClass = vi.fn();
+  const removeClass = vi.fn();
+  const showAlert = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resetDragDropHandler();
+    vi.stubGlobal('document', {
+      body: {
+        classList: {
+          add: addClass,
+          remove: removeClass,
+        },
+      },
+    });
+    vi.stubGlobal('alert', showAlert);
+  });
+
+  it('uses the Tauri 2 drag/drop API and reads paths from the v2 payload', async () => {
+    const tabManager = {} as TabManager;
+
+    await setupTauriListeners({
+      tabManager,
+      settingsManager: null,
+      keybindManager: null,
+      isMac: true,
+      openPdfAndRefresh: vi.fn(async () => undefined),
+      getInitialFilterSettings: () => ({ ...PRESETS.default }),
+      getInitialViewMode: () => 'single',
+      reloadSettings: vi.fn(async () => undefined),
+      applyWindowAfterOpen: vi.fn(async () => undefined),
+      updateTabBarVisibility: vi.fn(),
+      updatePrintMenuState: vi.fn(async () => undefined),
+      updateUI: vi.fn(),
+      saveCurrentTabState: vi.fn(),
+      printCurrentPDF: vi.fn(async () => undefined),
+    });
+
+    expect(mocks.onDragDropEvent).toHaveBeenCalledOnce();
+    expect(mocks.listen).not.toHaveBeenCalledWith('tauri://file-drop', expect.any(Function));
+
+    const handler = mocks.getDragDropHandler();
+    expect(handler).toBeDefined();
+
+    await handler?.({
+      payload: {
+        type: 'enter',
+        paths: ['/tmp/report.pdf'],
+        position: { x: 1, y: 2 } as never,
+      },
+    });
+    expect(addClass).toHaveBeenCalledWith('drag-over');
+
+    await handler?.({
+      payload: {
+        type: 'drop',
+        paths: ['/tmp/report.pdf', '/tmp/form.xfdf'],
+        position: { x: 1, y: 2 } as never,
+      },
+    });
+
+    expect(removeClass).toHaveBeenCalledWith('drag-over');
+    expect(mocks.openFiles).toHaveBeenCalledWith(
+      ['/tmp/report.pdf'],
+      expect.objectContaining({ tabManager, continueOnError: true }),
+    );
+  });
+});

--- a/src/app/dialogs.ts
+++ b/src/app/dialogs.ts
@@ -1,0 +1,121 @@
+export type PasswordRequestReason = 'required' | 'incorrect';
+
+function requireDialog(id: string): HTMLDialogElement {
+  const dialog = document.getElementById(id);
+  if (!(dialog instanceof HTMLDialogElement)) {
+    throw new Error(`Dialog '${id}' is not available`);
+  }
+  return dialog;
+}
+
+export function requestPdfPassword(
+  fileName: string,
+  reason: PasswordRequestReason,
+): Promise<string | null> {
+  const dialog = requireDialog('password-dialog');
+  const form = dialog.querySelector<HTMLFormElement>('form');
+  const title = dialog.querySelector<HTMLElement>('[data-password-title]');
+  const message = dialog.querySelector<HTMLElement>('[data-password-message]');
+  const input = dialog.querySelector<HTMLInputElement>('input[name="password"]');
+  const cancelButton = dialog.querySelector<HTMLButtonElement>('[data-dialog-cancel]');
+
+  if (!form || !input || !cancelButton) {
+    throw new Error('Password dialog is incomplete');
+  }
+
+  if (title) title.textContent = `Unlock ${fileName}`;
+  if (message) {
+    message.textContent =
+      reason === 'incorrect'
+        ? 'That password was incorrect. Please try again.'
+        : 'This PDF is encrypted. Enter its password to continue.';
+  }
+  input.value = '';
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value: string | null) => {
+      if (settled) return;
+      settled = true;
+      form.removeEventListener('submit', handleSubmit);
+      cancelButton.removeEventListener('click', handleCancel);
+      dialog.removeEventListener('cancel', handleDialogCancel);
+      if (dialog.open) dialog.close();
+      resolve(value);
+    };
+    const handleSubmit = (event: SubmitEvent) => {
+      event.preventDefault();
+      const password = input.value;
+      if (password.length > 0) finish(password);
+    };
+    const handleCancel = () => finish(null);
+    const handleDialogCancel = (event: Event) => {
+      event.preventDefault();
+      finish(null);
+    };
+
+    form.addEventListener('submit', handleSubmit);
+    cancelButton.addEventListener('click', handleCancel);
+    dialog.addEventListener('cancel', handleDialogCancel);
+    dialog.showModal();
+    input.focus();
+  });
+}
+
+export function requestAnnotationNote(initialValue = ''): Promise<string | null> {
+  const dialog = requireDialog('annotation-dialog');
+  const form = dialog.querySelector<HTMLFormElement>('form');
+  const input = dialog.querySelector<HTMLTextAreaElement>('textarea[name="note"]');
+  const cancelButton = dialog.querySelector<HTMLButtonElement>('[data-dialog-cancel]');
+
+  if (!form || !input || !cancelButton) {
+    throw new Error('Annotation dialog is incomplete');
+  }
+
+  input.value = initialValue;
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value: string | null) => {
+      if (settled) return;
+      settled = true;
+      form.removeEventListener('submit', handleSubmit);
+      cancelButton.removeEventListener('click', handleCancel);
+      dialog.removeEventListener('cancel', handleDialogCancel);
+      if (dialog.open) dialog.close();
+      resolve(value);
+    };
+    const handleSubmit = (event: SubmitEvent) => {
+      event.preventDefault();
+      finish(input.value.trim());
+    };
+    const handleCancel = () => finish(null);
+    const handleDialogCancel = (event: Event) => {
+      event.preventDefault();
+      finish(null);
+    };
+
+    form.addEventListener('submit', handleSubmit);
+    cancelButton.addEventListener('click', handleCancel);
+    dialog.addEventListener('cancel', handleDialogCancel);
+    dialog.showModal();
+    input.focus();
+    input.select();
+  });
+}
+
+export function showToast(message: string, tone: 'info' | 'error' = 'info'): void {
+  const region = document.getElementById('toast-region');
+  if (!region) return;
+
+  const toast = document.createElement('div');
+  toast.className = `toast toast-${tone}`;
+  toast.setAttribute('role', tone === 'error' ? 'alert' : 'status');
+  toast.textContent = message;
+  region.appendChild(toast);
+
+  window.setTimeout(() => {
+    toast.classList.add('toast-leaving');
+    window.setTimeout(() => toast.remove(), 180);
+  }, 3200);
+}

--- a/src/app/dom-events.ts
+++ b/src/app/dom-events.ts
@@ -1,3 +1,4 @@
+import { nextViewMode, viewModeIcon, viewModeLabel } from '../lib/document-features';
 import type { FilterSettings } from '../scripts/filters';
 import type { KeybindManager } from '../scripts/keybind-manager';
 import type { SliderManager } from '../scripts/sliders';
@@ -14,6 +15,8 @@ interface DomEventContext {
   onPresetApplied: (settings: FilterSettings) => void;
   saveCurrentTabState: () => void;
   updateUI: () => void;
+  openRecentFile: (filePath: string) => Promise<void>;
+  clearRecentFiles: () => Promise<void>;
 }
 
 // Setup event listeners
@@ -26,6 +29,8 @@ export function setupEventListeners({
   onPresetApplied,
   saveCurrentTabState,
   updateUI,
+  openRecentFile,
+  clearRecentFiles,
 }: DomEventContext): void {
   console.log('Setting up event listeners...');
 
@@ -40,6 +45,17 @@ export function setupEventListeners({
   } else {
     console.error('Splash open button not found!');
   }
+
+  document.getElementById('recent-files-list')?.addEventListener('click', (event) => {
+    const target = event.target;
+    const button =
+      target instanceof Element ? target.closest<HTMLButtonElement>('[data-file-path]') : null;
+    const filePath = button?.dataset.filePath;
+    if (filePath) void openRecentFile(filePath);
+  });
+  document.getElementById('clear-recent-files')?.addEventListener('click', () => {
+    void clearRecentFiles();
+  });
 
   // Open file button (in toolbar)
   const openBtn = document.getElementById('open-file');
@@ -130,7 +146,7 @@ export function setupEventListeners({
   toggleViewModeBtn?.addEventListener('click', () => {
     withActiveViewer(tabManager, async (viewer, tab) => {
       const currentMode = viewer.getState().viewMode;
-      const newMode = currentMode === 'single' ? 'continuous' : 'single';
+      const newMode = nextViewMode(currentMode);
       await viewer.setViewMode(newMode);
 
       // Update tab data
@@ -141,7 +157,11 @@ export function setupEventListeners({
       // Update button icon
       const icon = document.getElementById('view-mode-icon');
       if (icon) {
-        icon.textContent = newMode === 'continuous' ? '⊞' : '⊟';
+        icon.textContent = viewModeIcon(newMode);
+        icon.parentElement?.setAttribute(
+          'title',
+          `${viewModeLabel(newMode)} (click to change view)`,
+        );
       }
 
       saveCurrentTabState();

--- a/src/app/file-actions.ts
+++ b/src/app/file-actions.ts
@@ -82,8 +82,8 @@ export async function openPDFFile(
       multiple: true,
       filters: [
         {
-          name: 'Documents',
-          extensions: ['pdf', 'xdp', 'fdf', 'xfdf'],
+          name: 'PDF Documents',
+          extensions: ['pdf'],
         },
       ],
     });

--- a/src/app/file-actions.ts
+++ b/src/app/file-actions.ts
@@ -1,7 +1,9 @@
 import { invoke } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
+import type { ViewMode } from '../lib/document-features';
 import type { FilterSettings } from '../scripts/filters';
 import type { TabManager } from '../scripts/tabs';
+import { showToast } from './dialogs';
 import { withActiveViewer } from './viewer-helpers';
 
 interface OpenFilesOptions {
@@ -9,7 +11,7 @@ interface OpenFilesOptions {
   continueOnError?: boolean;
   onError?: (message: string) => void;
   initialFilterSettings?: FilterSettings;
-  initialViewMode?: 'single' | 'continuous';
+  initialViewMode?: ViewMode;
 }
 
 interface EnsureViewingSizeOptions {
@@ -72,7 +74,7 @@ export async function openFiles(
 export async function openPDFFile(
   tabManager: TabManager | null,
   initialFilterSettings?: FilterSettings,
-  initialViewMode?: 'single' | 'continuous',
+  initialViewMode?: ViewMode,
 ): Promise<number> {
   if (!tabManager) return 0;
   console.log('openPDFFile() called');
@@ -100,7 +102,10 @@ export async function openPDFFile(
     return await openFiles(files, { tabManager, initialFilterSettings, initialViewMode });
   } catch (error) {
     console.error('Error opening file:', error);
-    alert(`Failed to open file: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    if (!message.includes('Password entry cancelled')) {
+      showToast(`Failed to open file: ${message}`, 'error');
+    }
     return 0;
   }
 }
@@ -127,7 +132,7 @@ export async function ensureMinimumViewingSize({
 export async function printCurrentPDF(tabManager: TabManager | null): Promise<void> {
   const activeTab = tabManager?.getActiveTab();
   if (!activeTab) {
-    alert('No PDF is currently open.');
+    showToast('No PDF is currently open.', 'error');
     return;
   }
 
@@ -136,7 +141,10 @@ export async function printCurrentPDF(tabManager: TabManager | null): Promise<vo
       await viewer.print();
     } catch (error) {
       console.error('Print error:', error);
-      alert(`Failed to print: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      showToast(
+        `Failed to print: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        'error',
+      );
     }
   });
 }
@@ -147,6 +155,9 @@ export async function openSettings(): Promise<void> {
     await invoke('open_settings');
   } catch (error) {
     console.error('Error opening settings:', error);
-    alert(`Failed to open settings: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    showToast(
+      `Failed to open settings: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      'error',
+    );
   }
 }

--- a/src/app/keybinds.ts
+++ b/src/app/keybinds.ts
@@ -1,4 +1,5 @@
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
+import type { ViewMode } from '../lib/document-features';
 import type { FilterSettings } from '../scripts/filters';
 import type { KeybindManager } from '../scripts/keybind-manager';
 import type { TabManager } from '../scripts/tabs';
@@ -12,11 +13,13 @@ interface KeybindContext {
   printCurrentPDF: () => Promise<void>;
   openSettings: () => Promise<void>;
   getInitialFilterSettings: () => FilterSettings;
-  getInitialViewMode: () => 'single' | 'continuous';
+  getInitialViewMode: () => ViewMode;
   applyWindowAfterOpen: () => Promise<void>;
   updateTabBarVisibility: () => void;
   saveCurrentTabState: () => void;
   updateUI: () => void;
+  openSearch: () => void;
+  togglePresentationMode: () => Promise<void>;
 }
 
 // Register all keybind actions with the KeybindManager
@@ -32,6 +35,8 @@ export function registerKeybindActions({
   updateTabBarVisibility,
   saveCurrentTabState,
   updateUI,
+  openSearch,
+  togglePresentationMode,
 }: KeybindContext): void {
   if (!keybindManager) {
     console.error('KeybindManager not initialized');
@@ -49,6 +54,10 @@ export function registerKeybindActions({
 
   keybindManager.registerAction('openSettings', async () => {
     await openSettings();
+  });
+
+  keybindManager.registerAction('find', () => {
+    openSearch();
   });
 
   // Tab management
@@ -188,6 +197,10 @@ export function registerKeybindActions({
     const currentWindow = getCurrentWebviewWindow();
     const isFullscreen = await currentWindow.isFullscreen();
     await currentWindow.setFullscreen(!isFullscreen);
+  });
+
+  keybindManager.registerAction('presentationMode', async () => {
+    await togglePresentationMode();
   });
 
   console.log('All keybind actions registered');

--- a/src/app/presentation-controller.ts
+++ b/src/app/presentation-controller.ts
@@ -1,0 +1,82 @@
+import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
+import type { ViewMode } from '../lib/document-features';
+import type { PDFViewer } from '../scripts/pdf-viewer';
+
+interface PresentationControllerOptions {
+  getActiveViewer: () => PDFViewer | null;
+  onStateChanged: () => void;
+}
+
+export class PresentationController {
+  private readonly getActiveViewer: () => PDFViewer | null;
+  private readonly onStateChanged: () => void;
+  private active = false;
+  private previousViewMode: ViewMode = 'single';
+  private previousZoom = 1;
+  private wasFullscreen = false;
+
+  constructor(options: PresentationControllerOptions) {
+    this.getActiveViewer = options.getActiveViewer;
+    this.onStateChanged = options.onStateChanged;
+    document.getElementById('presentation-mode')?.addEventListener('click', () => {
+      void this.toggle();
+    });
+    document.addEventListener(
+      'keydown',
+      (event) => {
+        if (this.active && event.key === 'Escape') {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          void this.exit();
+        }
+      },
+      true,
+    );
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  async toggle(): Promise<void> {
+    if (this.active) {
+      await this.exit();
+    } else {
+      await this.enter();
+    }
+  }
+
+  async enter(): Promise<void> {
+    const viewer = this.getActiveViewer();
+    if (!viewer || this.active) return;
+
+    const state = viewer.getState();
+    this.previousViewMode = state.viewMode;
+    this.previousZoom = state.zoom;
+    const currentWindow = getCurrentWebviewWindow();
+    this.wasFullscreen = await currentWindow.isFullscreen();
+    this.active = true;
+    document.body.classList.add('presentation-mode');
+    if (!this.wasFullscreen) await currentWindow.setFullscreen(true);
+
+    await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+    await viewer.setViewMode('single');
+    await viewer.fitToPage();
+    this.onStateChanged();
+  }
+
+  async exit(): Promise<void> {
+    if (!this.active) return;
+    const viewer = this.getActiveViewer();
+    this.active = false;
+    document.body.classList.remove('presentation-mode');
+    const currentWindow = getCurrentWebviewWindow();
+    if (!this.wasFullscreen) await currentWindow.setFullscreen(false);
+
+    if (viewer) {
+      await viewer.setViewMode(this.previousViewMode);
+      await viewer.setZoom(this.previousZoom);
+    }
+    this.onStateChanged();
+  }
+}

--- a/src/app/search-controller.ts
+++ b/src/app/search-controller.ts
@@ -1,0 +1,178 @@
+import type { PdfSearchMatch } from '../lib/document-features';
+import type { PDFViewer } from '../scripts/pdf-viewer';
+
+export class SearchController {
+  private readonly getActiveViewer: () => PDFViewer | null;
+  private readonly bar: HTMLElement;
+  private readonly input: HTMLInputElement;
+  private readonly status: HTMLElement;
+  private readonly previousButton: HTMLButtonElement;
+  private readonly nextButton: HTMLButtonElement;
+  private matches: PdfSearchMatch[] = [];
+  private activeIndex = -1;
+  private searchTimer: number | null = null;
+  private searchEpoch = 0;
+  private searchedViewer: PDFViewer | null = null;
+
+  constructor(getActiveViewer: () => PDFViewer | null) {
+    this.getActiveViewer = getActiveViewer;
+    this.bar = this.requireElement<HTMLElement>('search-bar');
+    this.input = this.requireElement<HTMLInputElement>('search-input');
+    this.status = this.requireElement<HTMLElement>('search-status');
+    this.previousButton = this.requireElement<HTMLButtonElement>('search-previous');
+    this.nextButton = this.requireElement<HTMLButtonElement>('search-next');
+
+    this.input.addEventListener('input', () => this.scheduleSearch());
+    this.input.addEventListener('keydown', (event) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase() === 'f') {
+        event.preventDefault();
+        event.stopPropagation();
+        this.input.select();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        event.stopPropagation();
+        this.close();
+      } else if (event.key === 'Enter') {
+        event.preventDefault();
+        event.stopPropagation();
+        void this.move(event.shiftKey ? -1 : 1);
+      }
+    });
+    this.previousButton.addEventListener('click', () => void this.move(-1));
+    this.nextButton.addEventListener('click', () => void this.move(1));
+    this.requireElement<HTMLButtonElement>('search-close').addEventListener('click', () =>
+      this.close(),
+    );
+    this.requireElement<HTMLButtonElement>('open-search').addEventListener('click', () =>
+      this.open(),
+    );
+  }
+
+  private requireElement<T extends HTMLElement>(id: string): T {
+    const element = document.getElementById(id);
+    if (!element) throw new Error(`Search control '${id}' not found`);
+    return element as T;
+  }
+
+  open(): void {
+    if (!this.getActiveViewer()) return;
+    this.bar.classList.remove('hidden');
+    this.input.focus();
+    this.input.select();
+    if (this.input.value.trim() && this.searchedViewer !== this.getActiveViewer()) {
+      void this.runSearch();
+    }
+  }
+
+  close(): void {
+    this.searchEpoch += 1;
+    this.bar.classList.add('hidden');
+    this.clearSearchTimer();
+    this.searchedViewer?.clearSearch();
+    this.searchedViewer = null;
+    this.matches = [];
+    this.activeIndex = -1;
+    this.status.textContent = 'Type to search';
+    this.setNavigationEnabled(false);
+  }
+
+  activeDocumentChanged(): void {
+    this.searchEpoch += 1;
+    this.searchedViewer?.clearSearch();
+    this.searchedViewer = null;
+    this.matches = [];
+    this.activeIndex = -1;
+    if (!this.bar.classList.contains('hidden') && this.input.value.trim()) {
+      void this.runSearch();
+    } else {
+      this.status.textContent = this.input.value.trim()
+        ? 'Press Enter to search'
+        : 'Type to search';
+    }
+  }
+
+  private scheduleSearch(): void {
+    this.searchEpoch += 1;
+    this.searchedViewer?.clearSearch();
+    this.matches = [];
+    this.activeIndex = -1;
+    this.setNavigationEnabled(false);
+    this.clearSearchTimer();
+    this.searchTimer = window.setTimeout(() => {
+      this.searchTimer = null;
+      void this.runSearch();
+    }, 180);
+  }
+
+  private clearSearchTimer(): void {
+    if (this.searchTimer !== null) {
+      window.clearTimeout(this.searchTimer);
+      this.searchTimer = null;
+    }
+  }
+
+  private async runSearch(): Promise<void> {
+    const viewer = this.getActiveViewer();
+    const query = this.input.value.trim();
+    const epoch = ++this.searchEpoch;
+    this.searchedViewer?.clearSearch();
+    this.searchedViewer = viewer;
+    this.matches = [];
+    this.activeIndex = -1;
+
+    if (!viewer || !query) {
+      this.status.textContent = 'Type to search';
+      return;
+    }
+
+    this.status.textContent = 'Searching…';
+    this.setNavigationEnabled(false);
+    let matches: PdfSearchMatch[];
+    try {
+      matches = await viewer.searchText(query);
+    } catch (error) {
+      if (epoch !== this.searchEpoch) return;
+      console.error('Document search failed:', error);
+      this.status.textContent = 'Search unavailable';
+      this.setNavigationEnabled(false);
+      return;
+    }
+    if (epoch !== this.searchEpoch || viewer !== this.getActiveViewer()) return;
+
+    this.matches = matches;
+    this.setNavigationEnabled(matches.length > 0);
+    if (matches.length === 0) {
+      this.status.textContent = 'No matches';
+      return;
+    }
+
+    this.activeIndex = 0;
+    await viewer.revealSearchMatch(matches[0]);
+    this.updateStatus();
+  }
+
+  private async move(direction: -1 | 1): Promise<void> {
+    if (this.matches.length === 0) {
+      await this.runSearch();
+      return;
+    }
+
+    this.activeIndex = (this.activeIndex + direction + this.matches.length) % this.matches.length;
+    const viewer = this.getActiveViewer();
+    if (!viewer) return;
+    await viewer.revealSearchMatch(this.matches[this.activeIndex]);
+    this.updateStatus();
+  }
+
+  private updateStatus(): void {
+    const match = this.matches[this.activeIndex];
+    this.status.textContent = match
+      ? `${this.activeIndex + 1} of ${this.matches.length} · page ${match.pageNumber}`
+      : `${this.matches.length} matches`;
+  }
+
+  private setNavigationEnabled(enabled: boolean): void {
+    this.previousButton.disabled = !enabled;
+    this.nextButton.disabled = !enabled;
+  }
+}

--- a/src/app/session-state.ts
+++ b/src/app/session-state.ts
@@ -1,3 +1,4 @@
+import type { ViewMode } from '../lib/document-features';
 import type { FilterSettings } from '../scripts/filters';
 import type { ReadingSession, SavedTabSession } from '../scripts/settings';
 import type { SliderManager } from '../scripts/sliders';
@@ -14,7 +15,7 @@ interface RestoreSessionOptions {
   tabManager: TabManager;
   sliderManager: SliderManager | null;
   getInitialFilterSettings: () => FilterSettings;
-  getInitialViewMode: () => 'single' | 'continuous';
+  getInitialViewMode: () => ViewMode;
 }
 
 function toSavedTabSession(tab: TabData): SavedTabSession {

--- a/src/app/session-state.ts
+++ b/src/app/session-state.ts
@@ -24,6 +24,8 @@ function toSavedTabSession(tab: TabData): SavedTabSession {
     filterSettings: { ...tab.filterSettings },
     currentPage: tab.currentPage,
     zoom: tab.zoom,
+    rotation: tab.rotation,
+    scrollPosition: tab.scrollPosition,
     viewMode: tab.viewMode,
   };
 }
@@ -65,6 +67,8 @@ async function restoreSavedTab(
   restoredTab.filterSettings = { ...savedTab.filterSettings };
   restoredTab.currentPage = savedTab.currentPage;
   restoredTab.zoom = savedTab.zoom;
+  restoredTab.rotation = savedTab.rotation ?? 0;
+  restoredTab.scrollPosition = savedTab.scrollPosition ?? 0;
   restoredTab.viewMode = savedTab.viewMode;
 
   await restoreTabState(tabManager, sliderManager, restoredTab);

--- a/src/app/sidebar-controller.ts
+++ b/src/app/sidebar-controller.ts
@@ -1,0 +1,377 @@
+import type { PdfAnnotation, PdfOutlineItem } from '../lib/document-features';
+import type { PDFViewer } from '../scripts/pdf-viewer';
+
+type SidebarPanel = 'outline' | 'thumbnails' | 'annotations';
+
+interface SidebarControllerOptions {
+  getActiveViewer: () => PDFViewer | null;
+  requestAnnotationNote: (initialValue?: string) => Promise<string | null>;
+}
+
+export class SidebarController {
+  private readonly getActiveViewer: () => PDFViewer | null;
+  private readonly requestAnnotationNote: (initialValue?: string) => Promise<string | null>;
+  private readonly sidebar: HTMLElement;
+  private readonly content: HTMLElement;
+  private panel: SidebarPanel = 'outline';
+  private thumbnailsEnabled = true;
+  private renderEpoch = 0;
+  private thumbnailObserver: IntersectionObserver | null = null;
+
+  constructor(options: SidebarControllerOptions) {
+    this.getActiveViewer = options.getActiveViewer;
+    this.requestAnnotationNote = options.requestAnnotationNote;
+    this.sidebar = this.requireElement('document-sidebar');
+    this.content = this.requireElement('sidebar-content');
+
+    document.querySelectorAll<HTMLButtonElement>('[data-sidebar-tab]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const panel = button.dataset.sidebarTab as SidebarPanel | undefined;
+        if (panel) this.open(panel);
+      });
+    });
+    this.requireElement('close-sidebar').addEventListener('click', () => this.close());
+    this.requireElement('toggle-outline').addEventListener('click', () => this.toggle('outline'));
+    this.requireElement('toggle-thumbnails').addEventListener('click', () =>
+      this.toggle('thumbnails'),
+    );
+    this.requireElement('toggle-annotations').addEventListener('click', () =>
+      this.toggle('annotations'),
+    );
+    this.updateTabState();
+  }
+
+  private requireElement(id: string): HTMLElement {
+    const element = document.getElementById(id);
+    if (!element) throw new Error(`Sidebar control '${id}' not found`);
+    return element;
+  }
+
+  setThumbnailsEnabled(enabled: boolean): void {
+    this.thumbnailsEnabled = enabled;
+    this.requireElement('toggle-thumbnails').classList.toggle('hidden', !enabled);
+    this.requireElement('thumbnails-tab').classList.toggle('hidden', !enabled);
+    if (!enabled && this.panel === 'thumbnails') {
+      this.panel = 'outline';
+      if (!this.sidebar.classList.contains('hidden')) void this.render();
+    }
+    this.updateTabState();
+  }
+
+  activeDocumentChanged(): void {
+    this.renderEpoch += 1;
+    this.thumbnailObserver?.disconnect();
+    this.thumbnailObserver = null;
+    if (!this.sidebar.classList.contains('hidden')) {
+      void this.render();
+    }
+  }
+
+  viewerStateChanged(): void {
+    const state = this.getActiveViewer()?.getState();
+    if (!state) return;
+    this.content.querySelectorAll<HTMLElement>('[data-page-number]').forEach((element) => {
+      element.classList.toggle(
+        'active',
+        Number.parseInt(element.dataset.pageNumber ?? '0', 10) === state.currentPage,
+      );
+    });
+    if (this.panel === 'annotations') {
+      this.renderAnnotations();
+    }
+  }
+
+  annotationsChanged(): void {
+    if (this.panel === 'annotations' && !this.sidebar.classList.contains('hidden')) {
+      this.renderAnnotations();
+    }
+  }
+
+  open(panel: SidebarPanel): void {
+    if (panel === 'thumbnails' && !this.thumbnailsEnabled) return;
+    this.panel = panel;
+    this.sidebar.classList.remove('hidden');
+    this.updateTabState();
+    void this.render();
+  }
+
+  close(): void {
+    this.sidebar.classList.add('hidden');
+    this.renderEpoch += 1;
+    this.thumbnailObserver?.disconnect();
+    this.thumbnailObserver = null;
+  }
+
+  private toggle(panel: SidebarPanel): void {
+    if (!this.sidebar.classList.contains('hidden') && this.panel === panel) {
+      this.close();
+      return;
+    }
+    this.open(panel);
+  }
+
+  private updateTabState(): void {
+    document.querySelectorAll<HTMLButtonElement>('[data-sidebar-tab]').forEach((button) => {
+      const selected = button.dataset.sidebarTab === this.panel;
+      button.setAttribute('aria-selected', selected ? 'true' : 'false');
+      button.tabIndex = selected ? 0 : -1;
+    });
+  }
+
+  private async render(): Promise<void> {
+    const viewer = this.getActiveViewer();
+    const epoch = ++this.renderEpoch;
+    this.thumbnailObserver?.disconnect();
+    this.thumbnailObserver = null;
+
+    if (!viewer) {
+      this.renderEmpty('Open a PDF to use the document sidebar.');
+      return;
+    }
+
+    switch (this.panel) {
+      case 'outline':
+        await this.renderOutline(viewer, epoch);
+        break;
+      case 'thumbnails':
+        this.renderThumbnails(viewer, epoch);
+        break;
+      case 'annotations':
+        this.renderAnnotations();
+        break;
+    }
+  }
+
+  private async renderOutline(viewer: PDFViewer, epoch: number): Promise<void> {
+    this.content.replaceChildren(this.message('Loading table of contents…', 'sidebar-loading'));
+    let outline: PdfOutlineItem[];
+    try {
+      outline = await viewer.getOutlineItems();
+    } catch (error) {
+      console.error('Failed to load PDF outline:', error);
+      if (epoch === this.renderEpoch) {
+        this.renderEmpty('The table of contents could not be loaded.');
+      }
+      return;
+    }
+    if (epoch !== this.renderEpoch || viewer !== this.getActiveViewer()) return;
+    if (outline.length === 0) {
+      this.renderEmpty('This PDF does not contain a table of contents.');
+      return;
+    }
+
+    const list = document.createElement('ul');
+    list.className = 'outline-list';
+    this.appendOutlineItems(list, outline, viewer);
+    this.content.replaceChildren(list);
+  }
+
+  private appendOutlineItems(
+    parent: HTMLUListElement,
+    items: PdfOutlineItem[],
+    viewer: PDFViewer,
+  ): void {
+    for (const item of items) {
+      const listItem = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'outline-item-button';
+      button.textContent = item.title;
+      button.title = item.title;
+      button.style.fontWeight = item.bold ? '700' : '400';
+      button.style.fontStyle = item.italic ? 'italic' : 'normal';
+      button.disabled = item.pageNumber === null && !item.url;
+      if (item.pageNumber !== null) button.dataset.pageNumber = item.pageNumber.toString();
+      button.addEventListener('click', async () => {
+        await viewer.activateOutlineItem(item);
+        this.viewerStateChanged();
+      });
+      listItem.appendChild(button);
+
+      if (item.items.length > 0) {
+        const childList = document.createElement('ul');
+        this.appendOutlineItems(childList, item.items, viewer);
+        listItem.appendChild(childList);
+      }
+      parent.appendChild(listItem);
+    }
+  }
+
+  private renderThumbnails(viewer: PDFViewer, epoch: number): void {
+    const list = document.createElement('div');
+    list.className = 'thumbnail-list';
+    const { totalPages, currentPage } = viewer.getState();
+
+    for (let pageNumber = 1; pageNumber <= totalPages; pageNumber++) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'thumbnail-button';
+      button.dataset.pageNumber = pageNumber.toString();
+      button.classList.toggle('active', pageNumber === currentPage);
+
+      const preview = document.createElement('div');
+      preview.className = 'thumbnail-preview';
+      preview.textContent = 'Loading…';
+      const label = document.createElement('span');
+      label.textContent = `Page ${pageNumber}`;
+      button.append(preview, label);
+      button.addEventListener('click', async () => {
+        await viewer.goToPage(pageNumber);
+        this.viewerStateChanged();
+      });
+      list.appendChild(button);
+    }
+
+    this.content.replaceChildren(list);
+    const loadPreview = (button: HTMLButtonElement) => {
+      const pageNumber = Number.parseInt(button.dataset.pageNumber ?? '0', 10);
+      const preview = button.querySelector<HTMLElement>('.thumbnail-preview');
+      if (!preview || pageNumber < 1 || preview.dataset.loaded === 'true') return;
+      preview.dataset.loaded = 'true';
+      void viewer
+        .renderThumbnail(pageNumber)
+        .then((canvas) => {
+          if (epoch !== this.renderEpoch || viewer !== this.getActiveViewer()) return;
+          preview.replaceChildren(canvas);
+        })
+        .catch(() => {
+          preview.textContent = 'Preview unavailable';
+        });
+    };
+
+    const buttons = Array.from(list.querySelectorAll<HTMLButtonElement>('.thumbnail-button'));
+    if ('IntersectionObserver' in window) {
+      this.thumbnailObserver = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            if (!entry.isIntersecting) continue;
+            const button = entry.target as HTMLButtonElement;
+            this.thumbnailObserver?.unobserve(button);
+            loadPreview(button);
+          }
+        },
+        { root: this.content, rootMargin: '220px' },
+      );
+      buttons.forEach((button) => {
+        this.thumbnailObserver?.observe(button);
+      });
+    } else {
+      buttons.slice(0, 8).forEach(loadPreview);
+    }
+  }
+
+  private renderAnnotations(): void {
+    const viewer = this.getActiveViewer();
+    if (!viewer) {
+      this.renderEmpty('Open a PDF to add annotations.');
+      return;
+    }
+
+    const container = document.createElement('div');
+    const toolbar = document.createElement('div');
+    toolbar.className = 'annotation-toolbar';
+    const addNote = document.createElement('button');
+    addNote.type = 'button';
+    addNote.className = 'annotation-add';
+    addNote.textContent = `Add note to page ${viewer.getState().currentPage}`;
+    addNote.addEventListener('click', async () => {
+      const note = await this.requestAnnotationNote();
+      if (note) {
+        await viewer.addPageNote(note);
+        this.renderAnnotations();
+      }
+    });
+    toolbar.appendChild(addNote);
+    container.appendChild(toolbar);
+
+    const annotations = viewer
+      .getAnnotations()
+      .sort((a, b) => a.pageNumber - b.pageNumber || a.createdAt - b.createdAt);
+    if (annotations.length === 0) {
+      container.appendChild(
+        this.message(
+          'Select text and right-click to highlight it, or add a note to the current page.',
+          'sidebar-empty',
+        ),
+      );
+    } else {
+      annotations.forEach((annotation) => {
+        container.appendChild(this.createAnnotationCard(annotation, viewer));
+      });
+    }
+    this.content.replaceChildren(container);
+  }
+
+  private createAnnotationCard(annotation: PdfAnnotation, viewer: PDFViewer): HTMLElement {
+    const card = document.createElement('article');
+    card.className = 'annotation-card';
+    card.dataset.color = annotation.color;
+    card.dataset.annotationId = annotation.id;
+
+    const header = document.createElement('div');
+    header.className = 'annotation-card-header';
+    const pageButton = document.createElement('button');
+    pageButton.type = 'button';
+    pageButton.textContent = `Page ${annotation.pageNumber}`;
+    pageButton.addEventListener('click', () => void viewer.goToPage(annotation.pageNumber));
+    const kind = document.createElement('span');
+    kind.textContent = annotation.kind === 'highlight' ? 'Highlight' : 'Note';
+    header.append(pageButton, kind);
+    card.appendChild(header);
+
+    if (annotation.text) {
+      const quote = document.createElement('blockquote');
+      quote.textContent = annotation.text;
+      card.appendChild(quote);
+    }
+
+    const note = document.createElement('textarea');
+    note.value = annotation.note;
+    note.placeholder = 'Add a note…';
+    note.setAttribute('aria-label', `Note for annotation on page ${annotation.pageNumber}`);
+    note.addEventListener('input', () => {
+      viewer.updateAnnotation(annotation.id, { note: note.value.trim() });
+    });
+    card.appendChild(note);
+
+    const actions = document.createElement('div');
+    actions.className = 'annotation-card-actions';
+    const color = document.createElement('select');
+    color.setAttribute('aria-label', 'Highlight color');
+    for (const value of ['yellow', 'green', 'blue', 'pink'] as const) {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = value[0].toUpperCase() + value.slice(1);
+      option.selected = annotation.color === value;
+      color.appendChild(option);
+    }
+    color.addEventListener('change', () => {
+      viewer.updateAnnotation(annotation.id, {
+        color: color.value as PdfAnnotation['color'],
+      });
+      card.dataset.color = color.value;
+    });
+
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.textContent = 'Delete';
+    remove.addEventListener('click', () => {
+      viewer.removeAnnotation(annotation.id);
+      this.renderAnnotations();
+    });
+    actions.append(color, remove);
+    card.appendChild(actions);
+    return card;
+  }
+
+  private renderEmpty(text: string): void {
+    this.content.replaceChildren(this.message(text, 'sidebar-empty'));
+  }
+
+  private message(text: string, className: string): HTMLElement {
+    const message = document.createElement('p');
+    message.className = className;
+    message.textContent = text;
+    return message;
+  }
+}

--- a/src/app/tab-state.ts
+++ b/src/app/tab-state.ts
@@ -1,3 +1,4 @@
+import { viewModeIcon, viewModeLabel } from '../lib/document-features';
 import { buildFilterCSS } from '../scripts/filters';
 import type { SliderManager } from '../scripts/sliders';
 import type { TabData, TabManager } from '../scripts/tabs';
@@ -33,7 +34,11 @@ export async function restoreTabState(
   // Update view mode button icon
   const icon = document.getElementById('view-mode-icon');
   if (icon) {
-    icon.textContent = tab.viewMode === 'continuous' ? '⊞' : '⊟';
+    icon.textContent = viewModeIcon(tab.viewMode);
+    icon.parentElement?.setAttribute(
+      'title',
+      `${viewModeLabel(tab.viewMode)} (click to change view)`,
+    );
   }
 }
 

--- a/src/app/tab-state.ts
+++ b/src/app/tab-state.ts
@@ -3,7 +3,7 @@ import type { SliderManager } from '../scripts/sliders';
 import type { TabData, TabManager } from '../scripts/tabs';
 import { updateActivePresetButton } from './ui';
 
-// Restore tab state (filters, page, zoom, view mode)
+// Restore tab state (filters, page, zoom, rotation, precise scroll position, view mode)
 export async function restoreTabState(
   tabManager: TabManager | null,
   sliderManager: SliderManager | null,
@@ -12,15 +12,15 @@ export async function restoreTabState(
   const viewer = tabManager?.getViewerForTab(tab.id);
   if (!viewer) return;
 
-  // Restore view mode first (before page/zoom)
-  await viewer.setViewMode(tab.viewMode);
-
   // Apply saved filter
   viewer.applyFilter(buildFilterCSS(tab.filterSettings));
 
-  // Restore page and zoom
-  await viewer.goToPage(tab.currentPage);
+  // Apply geometry while still in single-page mode, then initialize the saved layout once.
+  await viewer.setRotation(tab.rotation);
   await viewer.setZoom(tab.zoom);
+  await viewer.setViewMode(tab.viewMode);
+  await viewer.goToPage(tab.currentPage);
+  await viewer.setScrollPosition(tab.scrollPosition);
 
   // Update slider if initialized
   if (sliderManager?.isInitialized()) {
@@ -53,6 +53,8 @@ export function saveCurrentTabState(
   // Save state to tab
   activeTab.currentPage = state.currentPage;
   activeTab.zoom = state.zoom;
+  activeTab.rotation = state.rotation;
+  activeTab.scrollPosition = viewer.getScrollPosition();
   activeTab.viewMode = state.viewMode;
 
   // Save current filter if sliders initialized

--- a/src/app/tauri-events.ts
+++ b/src/app/tauri-events.ts
@@ -2,6 +2,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { getCurrentWebview } from '@tauri-apps/api/webview';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
+import type { ViewMode } from '../lib/document-features';
 import type { FilterSettings } from '../scripts/filters';
 import type { KeybindManager } from '../scripts/keybind-manager';
 import type { SettingsManager } from '../scripts/settings';
@@ -16,7 +17,7 @@ interface TauriListenerContext {
   isMac: boolean;
   openPdfAndRefresh: () => Promise<void>;
   getInitialFilterSettings: () => FilterSettings;
-  getInitialViewMode: () => 'single' | 'continuous';
+  getInitialViewMode: () => ViewMode;
   reloadSettings: () => Promise<void>;
   applyWindowAfterOpen: () => Promise<void>;
   updateTabBarVisibility: () => void;

--- a/src/app/tauri-events.ts
+++ b/src/app/tauri-events.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
+import { getCurrentWebview } from '@tauri-apps/api/webview';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import type { FilterSettings } from '../scripts/filters';
 import type { KeybindManager } from '../scripts/keybind-manager';
@@ -43,7 +44,7 @@ export async function setupTauriListeners({
 }: TauriListenerContext): Promise<void> {
   const isSupportedFile = (path: string): boolean => {
     const ext = path.split('.').pop()?.toLowerCase();
-    return ext ? ['pdf', 'xdp', 'fdf', 'xfdf'].includes(ext) : false;
+    return ext === 'pdf';
   };
 
   const handleCliOpenPayload = async (payload: { files: string[]; page: number | null }) => {
@@ -80,15 +81,14 @@ export async function setupTauriListeners({
     }
   };
 
-  // Listen for file drop events
-  await listen<string[]>('tauri://file-drop', async (event) => {
-    console.log('File drop detected:', event.payload);
+  const handleDroppedFiles = async (paths: string[]): Promise<void> => {
+    console.log('File drop detected:', paths);
     if (!tabManager) return;
 
-    const pdfFiles = event.payload.filter((f) => isSupportedFile(f));
+    const pdfFiles = paths.filter((path) => isSupportedFile(path));
 
     if (pdfFiles.length === 0) {
-      alert('Please drop PDF/XDP/FDF/XFDF files only.');
+      alert('Please drop PDF files only.');
       return;
     }
 
@@ -113,15 +113,23 @@ export async function setupTauriListeners({
     await updatePrintMenuState();
 
     await applyWindowAfterOpen();
-  });
+  };
 
-  // Visual feedback for drag operations
-  await listen('tauri://file-drop-hover', async () => {
-    document.body.classList.add('drag-over');
-  });
-
-  await listen('tauri://file-drop-cancelled', async () => {
-    document.body.classList.remove('drag-over');
+  // Tauri 2 delivers a discriminated drag/drop payload through the current webview.
+  await getCurrentWebview().onDragDropEvent(async (event) => {
+    switch (event.payload.type) {
+      case 'enter':
+      case 'over':
+        document.body.classList.add('drag-over');
+        break;
+      case 'drop':
+        document.body.classList.remove('drag-over');
+        await handleDroppedFiles(event.payload.paths);
+        break;
+      case 'leave':
+        document.body.classList.remove('drag-over');
+        break;
+    }
   });
 
   // Listen for CLI file open events

--- a/src/app/ui.ts
+++ b/src/app/ui.ts
@@ -1,3 +1,8 @@
+import {
+  viewModeIcon as getViewModeIcon,
+  type RecentFile,
+  viewModeLabel,
+} from '../lib/document-features';
 import { type FilterSettings, PRESETS } from '../scripts/filters';
 import type { TabManager } from '../scripts/tabs';
 
@@ -15,6 +20,32 @@ export function showViewer(): void {
   const viewer = document.getElementById('viewer-container');
   if (splash) splash.classList.add('hidden');
   if (viewer) viewer.classList.remove('hidden');
+}
+
+export function renderRecentFiles(recentFiles: readonly RecentFile[]): void {
+  const section = document.getElementById('recent-files-section');
+  const list = document.getElementById('recent-files-list');
+  if (!section || !list) return;
+
+  section.classList.toggle('hidden', recentFiles.length === 0);
+  list.replaceChildren();
+
+  for (const recent of recentFiles) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'recent-file-button';
+    button.dataset.filePath = recent.filePath;
+    button.title = recent.filePath;
+
+    const title = document.createElement('span');
+    title.className = 'recent-file-title';
+    title.textContent = recent.title;
+    const path = document.createElement('span');
+    path.className = 'recent-file-path';
+    path.textContent = recent.filePath;
+    button.append(title, path);
+    list.appendChild(button);
+  }
 }
 
 // Update tab bar visibility
@@ -92,7 +123,11 @@ export function updateUI(tabManager: TabManager | null): void {
   // Update view mode icon
   const viewModeIcon = document.getElementById('view-mode-icon');
   if (viewModeIcon) {
-    viewModeIcon.textContent = state.viewMode === 'continuous' ? '⊞' : '⊟';
+    viewModeIcon.textContent = getViewModeIcon(state.viewMode);
+    viewModeIcon.parentElement?.setAttribute(
+      'title',
+      `${viewModeLabel(state.viewMode)} (click to change view)`,
+    );
   }
 
   // Update button states

--- a/src/lib/document-features.ts
+++ b/src/lib/document-features.ts
@@ -1,0 +1,121 @@
+export type ViewMode = 'single' | 'continuous' | 'spread';
+
+export const VIEW_MODE_SEQUENCE: readonly ViewMode[] = ['single', 'continuous', 'spread'];
+
+export function nextViewMode(mode: ViewMode): ViewMode {
+  const currentIndex = VIEW_MODE_SEQUENCE.indexOf(mode);
+  return VIEW_MODE_SEQUENCE[(currentIndex + 1) % VIEW_MODE_SEQUENCE.length];
+}
+
+export function viewModeLabel(mode: ViewMode): string {
+  switch (mode) {
+    case 'single':
+      return 'Single page';
+    case 'continuous':
+      return 'Continuous scroll';
+    case 'spread':
+      return 'Two-page spread';
+  }
+}
+
+export function viewModeIcon(mode: ViewMode): string {
+  switch (mode) {
+    case 'single':
+      return '⊟';
+    case 'continuous':
+      return '⊞';
+    case 'spread':
+      return '▥';
+  }
+}
+
+export interface PdfSearchMatch {
+  pageNumber: number;
+  pageOccurrence: number;
+  index: number;
+  excerpt: string;
+}
+
+export function findPageTextMatches(
+  pageText: string,
+  query: string,
+  pageNumber: number,
+): PdfSearchMatch[] {
+  const needle = query.trim().toLocaleLowerCase();
+  if (!needle) return [];
+
+  const haystack = pageText.toLocaleLowerCase();
+  const matches: PdfSearchMatch[] = [];
+  let fromIndex = 0;
+  let pageOccurrence = 0;
+
+  while (fromIndex <= haystack.length - needle.length) {
+    const index = haystack.indexOf(needle, fromIndex);
+    if (index === -1) break;
+
+    const excerptStart = Math.max(0, index - 35);
+    const excerptEnd = Math.min(pageText.length, index + needle.length + 55);
+    const prefix = excerptStart > 0 ? '…' : '';
+    const suffix = excerptEnd < pageText.length ? '…' : '';
+
+    matches.push({
+      pageNumber,
+      pageOccurrence,
+      index,
+      excerpt: `${prefix}${pageText.slice(excerptStart, excerptEnd).replace(/\s+/g, ' ').trim()}${suffix}`,
+    });
+
+    pageOccurrence += 1;
+    fromIndex = index + Math.max(needle.length, 1);
+  }
+
+  return matches;
+}
+
+export interface PdfOutlineItem {
+  title: string;
+  pageNumber: number | null;
+  url?: string;
+  bold: boolean;
+  italic: boolean;
+  items: PdfOutlineItem[];
+}
+
+export type PdfAnnotationKind = 'highlight' | 'note';
+export type PdfAnnotationColor = 'yellow' | 'green' | 'blue' | 'pink';
+
+export interface PdfAnnotationRect {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+export interface PdfAnnotation {
+  id: string;
+  kind: PdfAnnotationKind;
+  pageNumber: number;
+  rects: PdfAnnotationRect[];
+  text: string;
+  note: string;
+  color: PdfAnnotationColor;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface RecentFile {
+  filePath: string;
+  title: string;
+  openedAt: number;
+}
+
+export function updateRecentFiles(
+  recentFiles: readonly RecentFile[],
+  opened: RecentFile,
+  limit = 8,
+): RecentFile[] {
+  return [opened, ...recentFiles.filter((recent) => recent.filePath !== opened.filePath)].slice(
+    0,
+    Math.max(0, limit),
+  );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,24 +1,36 @@
 import { getName, getTauriVersion, getVersion } from '@tauri-apps/api/app';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
+import { requestAnnotationNote, requestPdfPassword, showToast } from './app/dialogs';
 import { setupEventListeners } from './app/dom-events';
 import {
   ensureMinimumViewingSize,
+  openFiles,
   openPDFFile,
   openSettings,
   printCurrentPDF,
   updatePrintMenuState,
 } from './app/file-actions';
 import { registerKeybindActions } from './app/keybinds';
+import { PresentationController } from './app/presentation-controller';
+import { SearchController } from './app/search-controller';
 import { captureReadingSession, restoreReadingSession } from './app/session-state';
+import { SidebarController } from './app/sidebar-controller';
 import { restoreTabState, saveCurrentTabState } from './app/tab-state';
 import { setupTauriListeners } from './app/tauri-events';
 import {
+  renderRecentFiles,
   showSplash,
   showViewer,
   updateKeyboardHints,
   updateTabBarVisibility,
   updateUI,
 } from './app/ui';
+import {
+  type PdfAnnotation,
+  type RecentFile,
+  updateRecentFiles,
+  type ViewMode,
+} from './lib/document-features';
 import { buildFilterCSS, type FilterSettings, PRESETS } from './scripts/filters';
 import { KeybindManager } from './scripts/keybind-manager';
 import { type MoonightSettings, SettingsManager } from './scripts/settings';
@@ -27,6 +39,7 @@ import { type TabData, TabManager } from './scripts/tabs';
 import './styles/main.css';
 import './styles/pdf-viewer.css';
 import './styles/configurator.css';
+import './styles/document-features.css';
 import './styles/tabs.css';
 import 'nouislider/dist/nouislider.css';
 
@@ -48,6 +61,9 @@ let currentSettings: MoonightSettings | null = null;
 
 // Global keybind manager instance
 let keybindManager: KeybindManager | null = null;
+let searchController: SearchController | null = null;
+let sidebarController: SidebarController | null = null;
+let presentationController: PresentationController | null = null;
 
 // Detect if we're on macOS
 const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
@@ -102,7 +118,7 @@ const getInitialFilterSettings = (): FilterSettings => {
   return { ...(preset ?? PRESETS.default) };
 };
 
-const getInitialViewMode = (): 'single' | 'continuous' => {
+const getInitialViewMode = (): ViewMode => {
   if (!currentSettings) {
     return 'single';
   }
@@ -112,7 +128,72 @@ const getInitialViewMode = (): 'single' | 'continuous' => {
 
 let lastFilterSaveTimer: number | null = null;
 let sessionSaveTimer: number | null = null;
+let annotationSaveTimer: number | null = null;
 let isRestoringSession = false;
+
+const getActiveViewer = () => {
+  const activeTab = tabManager?.getActiveTab();
+  return activeTab ? (tabManager?.getViewerForTab(activeTab.id) ?? null) : null;
+};
+
+const persistAnnotations = (filePath: string, annotations: PdfAnnotation[]): void => {
+  const manager = settingsManager;
+  if (!manager || !currentSettings) return;
+
+  const annotationMap = {
+    ...currentSettings.annotations,
+    [filePath]: annotations,
+  };
+  currentSettings = { ...currentSettings, annotations: annotationMap };
+  if (annotationSaveTimer !== null) window.clearTimeout(annotationSaveTimer);
+  annotationSaveTimer = window.setTimeout(async () => {
+    try {
+      await manager.set('annotations', currentSettings?.annotations ?? {});
+    } catch (error) {
+      console.error('Failed to save annotations:', error);
+      showToast('Could not save annotations.', 'error');
+    } finally {
+      annotationSaveTimer = null;
+    }
+  }, 200);
+};
+
+const rememberRecentFile = (filePath: string, title: string): void => {
+  const manager = settingsManager;
+  if (!manager || !currentSettings) return;
+  const opened: RecentFile = { filePath, title, openedAt: Date.now() };
+  const recentFiles = updateRecentFiles(currentSettings.recentFiles, opened);
+  currentSettings = { ...currentSettings, recentFiles };
+  renderRecentFiles(recentFiles);
+  void manager.set('recentFiles', recentFiles).catch((error) => {
+    console.error('Failed to save recent files:', error);
+  });
+};
+
+const clearRecentFiles = async (): Promise<void> => {
+  if (!settingsManager || !currentSettings) return;
+  currentSettings = { ...currentSettings, recentFiles: [] };
+  renderRecentFiles([]);
+  await settingsManager.set('recentFiles', []);
+};
+
+const openRecentFile = async (filePath: string): Promise<void> => {
+  if (!tabManager) return;
+  try {
+    await openFiles([filePath], {
+      tabManager,
+      initialFilterSettings: getInitialFilterSettings(),
+      initialViewMode: getInitialViewMode(),
+    });
+    showViewer();
+    await refreshAfterOpen();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    if (!message.includes('Password entry cancelled')) {
+      showToast(`Could not open recent file: ${message}`, 'error');
+    }
+  }
+};
 
 const scheduleLastFilterSave = (settings: FilterSettings): void => {
   const manager = settingsManager;
@@ -205,6 +286,7 @@ async function initializeApp(): Promise<void> {
     settingsManager = new SettingsManager();
     const settings = await settingsManager.load();
     currentSettings = settings;
+    renderRecentFiles(settings.recentFiles);
     console.log('Settings loaded:', settings);
 
     // Initialize tab manager
@@ -219,6 +301,8 @@ async function initializeApp(): Promise<void> {
           // No tabs - show splash
           showSplash();
         }
+        searchController?.activeDocumentChanged();
+        sidebarController?.activeDocumentChanged();
         updateTabBarVisibility(tabManager);
         // Update print menu state
         await updatePrintMenuState(tabManager);
@@ -227,10 +311,38 @@ async function initializeApp(): Promise<void> {
       () => {
         saveCurrentTabState(tabManager, sliderManager);
         updateUI(tabManager);
+        sidebarController?.viewerStateChanged();
         scheduleReadingSessionSave();
       },
       scheduleReadingSessionSave,
+      {
+        getAnnotations: (filePath) => currentSettings?.annotations[filePath] ?? [],
+        onAnnotationsChanged: (filePath, annotations) => {
+          persistAnnotations(filePath, annotations);
+          sidebarController?.annotationsChanged();
+        },
+        onDocumentOpened: (tab) => {
+          if (!isRestoringSession) rememberRecentFile(tab.filePath, tab.title);
+        },
+        requestPassword: requestPdfPassword,
+        requestAnnotationNote,
+      },
     );
+
+    searchController = new SearchController(getActiveViewer);
+    sidebarController = new SidebarController({
+      getActiveViewer,
+      requestAnnotationNote,
+    });
+    sidebarController.setThumbnailsEnabled(settings.general.displayThumbs);
+    presentationController = new PresentationController({
+      getActiveViewer,
+      onStateChanged: () => {
+        saveCurrentTabState(tabManager, sliderManager);
+        updateUI(tabManager);
+        scheduleReadingSessionSave();
+      },
+    });
 
     // Initialize slider manager
     sliderManager = new SliderManager((filterSettings) => {
@@ -271,6 +383,10 @@ async function initializeApp(): Promise<void> {
       updateTabBarVisibility: updateTabBar,
       saveCurrentTabState: saveStateForTab,
       updateUI: updateUIForTab,
+      openSearch: () => searchController?.open(),
+      togglePresentationMode: async () => {
+        await presentationController?.toggle();
+      },
     });
 
     // Load keybinds from settings
@@ -300,6 +416,8 @@ async function initializeApp(): Promise<void> {
       onPresetApplied: scheduleLastFilterSave,
       saveCurrentTabState: saveStateForTab,
       updateUI: updateUIForTab,
+      openRecentFile,
+      clearRecentFiles,
     });
 
     // Update keyboard hints for platform
@@ -324,6 +442,8 @@ async function initializeApp(): Promise<void> {
           updated.keybinds.Settings.binds = ['Cmd+,'];
         }
         currentSettings = updated;
+        renderRecentFiles(updated.recentFiles);
+        sidebarController?.setThumbnailsEnabled(updated.general.displayThumbs);
         if (!updated.general.rememberLastFilter && lastFilterSaveTimer !== null) {
           clearTimeout(lastFilterSaveTimer);
           lastFilterSaveTimer = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,10 +211,10 @@ async function initializeApp(): Promise<void> {
     tabManager = new TabManager(
       async (tab: TabData | null) => {
         if (tab) {
-          // Tab activated - restore its state
+          // Reveal the already-rendered first page while any remaining state/layout is restored.
+          showViewer();
           await restoreTabState(tabManager, sliderManager, tab);
           updateUI(tabManager);
-          showViewer();
         } else {
           // No tabs - show splash
           showSplash();

--- a/src/scripts/keybind-manager.ts
+++ b/src/scripts/keybind-manager.ts
@@ -24,8 +24,10 @@ type KeybindAction = (e: KeyboardEvent, data?: string) => void | Promise<void>;
  */
 export class KeybindManager {
   private keybinds: Map<string, ParsedKeybind[]> = new Map();
+  private configuredActions: Map<string, string> = new Map();
   private actionHandlers: Map<string, KeybindAction> = new Map();
   private actionData: Map<string, string> = new Map();
+  private registeredActionData: Map<string, string> = new Map();
   private isMac: boolean;
 
   constructor(isMac: boolean) {
@@ -69,6 +71,12 @@ export class KeybindManager {
         case 'option':
           result.alt = true;
           break;
+        case 'plus':
+          result.key = '+';
+          break;
+        case 'minus':
+          result.key = '-';
+          break;
         default:
           // The actual key - normalize to lowercase for matching
           result.key = part.toLowerCase();
@@ -84,7 +92,7 @@ export class KeybindManager {
   registerAction(actionId: string, handler: KeybindAction, data?: string): void {
     this.actionHandlers.set(actionId, handler);
     if (data) {
-      this.actionData.set(actionId, data);
+      this.registeredActionData.set(actionId, data);
     }
   }
 
@@ -93,18 +101,20 @@ export class KeybindManager {
    */
   loadFromSettings(settings: MoonightSettings): void {
     this.keybinds.clear();
+    this.configuredActions.clear();
+    this.actionData.clear();
 
-    for (const [actionId, config] of Object.entries(settings.keybinds)) {
+    for (const [bindingId, config] of Object.entries(settings.keybinds)) {
       if (config.binds.length === 0) continue;
 
-      const actionKey = config.action || actionId;
       const parsed: ParsedKeybind[] = config.binds.map((bind) => this.parseAccelerator(bind));
 
-      this.keybinds.set(actionKey, parsed);
+      this.keybinds.set(bindingId, parsed);
+      this.configuredActions.set(bindingId, config.action || bindingId);
 
       // Store action data if present
       if (config.data) {
-        this.actionData.set(actionKey, config.data);
+        this.actionData.set(bindingId, config.data);
       }
     }
 
@@ -116,6 +126,17 @@ export class KeybindManager {
    * Returns the action ID or null if no match
    */
   matchEvent(e: KeyboardEvent): string | null {
+    const bindingId = this.findMatchingBinding(e);
+    if (!bindingId) return null;
+
+    return this.configuredActions.get(bindingId) ?? bindingId;
+  }
+
+  private findMatchingBinding(e: KeyboardEvent): string | null {
+    if (this.isEditableTarget(e.target)) {
+      return null;
+    }
+
     const eventKey = e.key.toLowerCase();
 
     // Ignore modifier-only presses
@@ -128,16 +149,17 @@ export class KeybindManager {
       return null;
     }
 
-    for (const [actionId, keybinds] of this.keybinds) {
+    for (const [bindingId, keybinds] of this.keybinds) {
       for (const kb of keybinds) {
+        const shiftMatches = kb.shift === e.shiftKey || (kb.key === '+' && !kb.shift && e.shiftKey);
         if (
           kb.key === eventKey &&
           kb.ctrl === e.ctrlKey &&
           kb.meta === e.metaKey &&
-          kb.shift === e.shiftKey &&
+          shiftMatches &&
           kb.alt === e.altKey
         ) {
-          return actionId;
+          return bindingId;
         }
       }
     }
@@ -145,20 +167,38 @@ export class KeybindManager {
     return null;
   }
 
+  private isEditableTarget(target: EventTarget | null): boolean {
+    if (!target || typeof target !== 'object') return false;
+
+    const element = target as {
+      tagName?: string;
+      isContentEditable?: boolean;
+    };
+    const tagName = element.tagName?.toLowerCase();
+
+    return (
+      tagName === 'input' ||
+      tagName === 'textarea' ||
+      tagName === 'select' ||
+      element.isContentEditable === true
+    );
+  }
+
   /**
    * Execute the action for a matched keyboard event
    */
   async handleEvent(e: KeyboardEvent): Promise<void> {
-    const actionId = this.matchEvent(e);
-    if (!actionId) return;
+    const bindingId = this.findMatchingBinding(e);
+    if (!bindingId) return;
 
+    const actionId = this.configuredActions.get(bindingId) ?? bindingId;
     const handler = this.actionHandlers.get(actionId);
     if (!handler) {
       console.warn(`No handler registered for action: ${actionId}`);
       return;
     }
 
-    const data = this.actionData.get(actionId);
+    const data = this.actionData.get(bindingId) ?? this.registeredActionData.get(actionId);
     await handler(e, data);
   }
 

--- a/src/scripts/pdf-viewer.ts
+++ b/src/scripts/pdf-viewer.ts
@@ -1,6 +1,15 @@
 import { invoke } from '@tauri-apps/api/core';
 import type { PDFDocumentProxy, PDFPageProxy, RenderTask, TextLayer } from 'pdfjs-dist';
 import { deriveScaledDimensions } from '../lib/dimensions';
+import {
+  findPageTextMatches,
+  type PdfAnnotation,
+  type PdfAnnotationColor,
+  type PdfAnnotationRect,
+  type PdfOutlineItem,
+  type PdfSearchMatch,
+  type ViewMode,
+} from '../lib/document-features';
 import { hasValueChanged } from '../lib/guards';
 import {
   computeSafeOutputScale,
@@ -27,7 +36,7 @@ interface ViewState {
   rotation: number;
   fileName: string;
   filePath: string;
-  viewMode: 'single' | 'continuous';
+  viewMode: ViewMode;
 }
 
 interface VisibleRenderRequest {
@@ -51,8 +60,43 @@ interface PageSurface {
   canvas: HTMLCanvasElement;
   textLayer: HTMLDivElement;
   linkLayer: HTMLDivElement;
+  userAnnotationLayer: HTMLDivElement;
   textLayerTask: TextLayerTask | null;
   layerEpoch: number;
+  pageNumber: number | null;
+  viewport: PageViewport | null;
+}
+
+interface RawOutlineItem {
+  title: string;
+  bold: boolean;
+  italic: boolean;
+  dest: PdfDestination | null;
+  url: string | null;
+  unsafeUrl?: string;
+  items: RawOutlineItem[];
+}
+
+interface GestureLikeEvent extends Event {
+  scale?: number;
+}
+
+interface SelectionHighlightData {
+  pageNumber: number;
+  rects: PdfAnnotationRect[];
+  text: string;
+}
+
+export type PdfPasswordRequester = (
+  fileName: string,
+  reason: 'required' | 'incorrect',
+) => Promise<string | null>;
+
+export type AnnotationNoteRequester = (initialValue?: string) => Promise<string | null>;
+
+export interface PDFViewerOptions {
+  requestPassword?: PdfPasswordRequester;
+  requestAnnotationNote?: AnnotationNoteRequester;
 }
 
 // Align canvas size to PDF.js viewer rounding to avoid subpixel blur.
@@ -133,6 +177,7 @@ export class PDFViewer {
   private container: HTMLElement;
   private canvas: HTMLCanvasElement | null = null;
   private singlePageSurface: PageSurface | null = null;
+  private spreadPageSurface: PageSurface | null = null;
   private pdfDoc: PDFDocumentProxy | null = null;
   private state: ViewState = {
     currentPage: 1,
@@ -144,17 +189,35 @@ export class PDFViewer {
     viewMode: 'single',
   };
   private renderTask: RenderTask | null = null;
+  private spreadRenderTask: RenderTask | null = null;
   private canvasId: string;
   private currentFilterCSS = '';
   private onPageChange: ((pageNum: number) => void) | null = null;
   private onScrollChange: ((scrollPosition: number) => void) | null = null;
+  private onAnnotationsChange: ((annotations: PdfAnnotation[]) => void) | null = null;
+  private annotations: PdfAnnotation[] = [];
+  private searchQuery = '';
+  private searchMatches: PdfSearchMatch[] = [];
+  private activeSearchMatch: PdfSearchMatch | null = null;
+  private pendingSelectionHighlights: SelectionHighlightData[] = [];
+  private readonly pageTextCache = new Map<number, string>();
+  private requestPassword?: PdfPasswordRequester;
+  private requestAnnotationNote?: AnnotationNoteRequester;
   private readonly linkTargets = new WeakMap<HTMLElement, PdfLinkTarget>();
   private contextMenu: HTMLDivElement | null = null;
   private handleDocumentPointerDownBound: (event: PointerEvent) => void;
   private handleDocumentPointerUpBound: () => void;
   private handleDocumentKeyDownBound: (event: KeyboardEvent) => void;
   private handleSelectionChangeBound: () => void;
+  private handleWheelBound: (event: WheelEvent) => void;
+  private handleGestureStartBound: (event: Event) => void;
+  private handleGestureChangeBound: (event: Event) => void;
   private isPointerDown = false;
+  private isVisible = false;
+  private wheelZoomRafId: number | null = null;
+  private pendingWheelDelta = 0;
+  private pinchStartZoom = 1;
+  private pinchRenderEpoch = 0;
 
   // Continuous scroll properties
   private canvases: Map<number, HTMLCanvasElement> = new Map();
@@ -177,19 +240,28 @@ export class PDFViewer {
   private handleScrollBound: () => void;
   private isScrollListenerAttached = false;
 
-  constructor(containerId: string, canvasId: string = 'pdf-canvas') {
+  constructor(
+    containerId: string,
+    canvasId: string = 'pdf-canvas',
+    options: PDFViewerOptions = {},
+  ) {
     const container = document.getElementById(containerId);
     if (!container) {
       throw new Error(`Container element '${containerId}' not found`);
     }
     this.container = container;
     this.canvasId = canvasId;
+    this.requestPassword = options.requestPassword;
+    this.requestAnnotationNote = options.requestAnnotationNote;
     this.initializeCanvas();
     this.handleScrollBound = this.handleScroll.bind(this);
     this.handleDocumentPointerDownBound = this.handleDocumentPointerDown.bind(this);
     this.handleDocumentPointerUpBound = this.handleDocumentPointerUp.bind(this);
     this.handleDocumentKeyDownBound = this.handleDocumentKeyDown.bind(this);
     this.handleSelectionChangeBound = this.handleSelectionChange.bind(this);
+    this.handleWheelBound = this.handleWheel.bind(this);
+    this.handleGestureStartBound = this.handleGestureStart.bind(this);
+    this.handleGestureChangeBound = this.handleGestureChange.bind(this);
     document.addEventListener('pointerdown', this.handleDocumentPointerDownBound, true);
     document.addEventListener('pointerup', this.handleDocumentPointerUpBound, true);
     document.addEventListener('keydown', this.handleDocumentKeyDownBound);
@@ -204,8 +276,13 @@ export class PDFViewer {
     this.onScrollChange = handler;
   }
 
+  setOnAnnotationsChange(handler: ((annotations: PdfAnnotation[]) => void) | null): void {
+    this.onAnnotationsChange = handler;
+  }
+
   private initializeCanvas(): void {
     const surface = this.createPageSurface(this.canvasId);
+    surface.wrapper.classList.add('spread-primary');
     this.singlePageSurface = surface;
     this.canvas = surface.canvas;
     this.container.appendChild(surface.wrapper);
@@ -236,15 +313,21 @@ export class PDFViewer {
     linkLayer.className = 'annotationLayer pdf-link-layer';
     linkLayer.setAttribute('aria-hidden', 'false');
 
-    wrapper.append(canvas, textLayer, linkLayer);
+    const userAnnotationLayer = document.createElement('div');
+    userAnnotationLayer.className = 'user-annotation-layer';
+
+    wrapper.append(canvas, userAnnotationLayer, textLayer, linkLayer);
 
     return {
       wrapper,
       canvas,
       textLayer,
       linkLayer,
+      userAnnotationLayer,
       textLayerTask: null,
       layerEpoch: 0,
+      pageNumber: pageNum ?? null,
+      viewport: null,
     };
   }
 
@@ -262,6 +345,9 @@ export class PDFViewer {
     surface.textLayer.style.setProperty('--total-scale-factor', `${viewport.scale}`);
     surface.linkLayer.style.width = `${width}px`;
     surface.linkLayer.style.height = `${height}px`;
+    surface.userAnnotationLayer.style.width = `${width}px`;
+    surface.userAnnotationLayer.style.height = `${height}px`;
+    surface.viewport = viewport;
   }
 
   private resetPageLayers(surface: PageSurface): number {
@@ -272,6 +358,7 @@ export class PDFViewer {
     }
     surface.textLayer.replaceChildren();
     surface.linkLayer.replaceChildren();
+    surface.userAnnotationLayer.replaceChildren();
     return surface.layerEpoch;
   }
 
@@ -284,6 +371,8 @@ export class PDFViewer {
   }
 
   async loadPDF(pdfData: Uint8Array, fileName: string, filePath: string): Promise<void> {
+    let passwordCancelled = false;
+    let passwordRequestError: unknown = null;
     try {
       // Cancel any pending render
       if (this.renderTask) {
@@ -295,6 +384,30 @@ export class PDFViewer {
 
       // Load PDF document
       const loadingTask = pdfjsLib.getDocument({ data: pdfData });
+      const passwordRequester = this.requestPassword;
+      if (passwordRequester) {
+        loadingTask.onPassword = (updatePassword: (password: string) => void, reason: number) => {
+          const requestReason =
+            reason === pdfjsLib.PasswordResponses.INCORRECT_PASSWORD ? 'incorrect' : 'required';
+          void passwordRequester(fileName, requestReason)
+            .then(async (password) => {
+              if (password === null) {
+                passwordCancelled = true;
+                await loadingTask.destroy();
+                return;
+              }
+              updatePassword(password);
+            })
+            .catch(async (error) => {
+              passwordRequestError = error;
+              try {
+                await loadingTask.destroy();
+              } catch {
+                // The original password UI error is the useful failure to report.
+              }
+            });
+        };
+      }
       this.pdfDoc = await loadingTask.promise;
 
       // Update state
@@ -305,11 +418,25 @@ export class PDFViewer {
 
       // Render page one immediately. Other dimensions are cached lazily as pages are requested.
       this.baseDimensions.clear();
+      this.pageTextCache.clear();
+      this.clearSearch();
       await this.renderPage(1);
 
       console.log(`Loaded PDF: ${fileName} (${this.state.totalPages} pages)`);
     } catch (error) {
       console.error('Error loading PDF:', error);
+      if (passwordCancelled) {
+        throw new Error('Password entry cancelled');
+      }
+      if (passwordRequestError) {
+        throw new Error(
+          `Password prompt failed: ${
+            passwordRequestError instanceof Error
+              ? passwordRequestError.message
+              : String(passwordRequestError)
+          }`,
+        );
+      }
       throw new Error(
         `Failed to load PDF: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
@@ -326,6 +453,9 @@ export class PDFViewer {
       this.renderTextLayer(page, viewport, surface, layerEpoch),
       this.renderLinkLayer(page, viewport, surface, layerEpoch),
     ]);
+    if (surface.layerEpoch === layerEpoch) {
+      this.renderUserAnnotations(surface, viewport);
+    }
   }
 
   private async renderTextLayer(
@@ -356,6 +486,7 @@ export class PDFViewer {
       if (surface.textLayerTask === textLayer) {
         surface.textLayerTask = null;
       }
+      this.applySearchHighlights(surface);
     } catch (error) {
       if (!isAbortLikeError(error)) {
         console.error('Error rendering text layer:', error);
@@ -512,7 +643,10 @@ export class PDFViewer {
     const linkElement =
       target instanceof Element ? target.closest<HTMLElement>('[data-pdf-link="true"]') : null;
     const linkTarget = linkElement ? this.linkTargets.get(linkElement) : undefined;
-    const selectedText = this.getSelectedText();
+    this.pendingSelectionHighlights = this.captureSelectionHighlights();
+    const selectedText = this.pendingSelectionHighlights
+      .map((selection) => selection.text)
+      .join(' ');
 
     if (!linkTarget && !selectedText) {
       this.hideContextMenu();
@@ -551,11 +685,25 @@ export class PDFViewer {
     }
 
     if (selectedText) {
-      menu.appendChild(
+      menu.append(
         this.createContextMenuButton('Copy Text', () => {
           void this.copyText(selectedText);
         }),
+        this.createContextMenuButton('Highlight Selection', () => {
+          this.addPendingSelectionHighlights('');
+        }),
       );
+
+      const noteRequester = this.requestAnnotationNote;
+      if (noteRequester) {
+        menu.appendChild(
+          this.createContextMenuButton('Highlight with Note…', () => {
+            void noteRequester().then((note) => {
+              if (note !== null) this.addPendingSelectionHighlights(note);
+            });
+          }),
+        );
+      }
     }
 
     menu.style.display = 'block';
@@ -654,45 +802,215 @@ export class PDFViewer {
     if (this.singlePageSurface) {
       surfaces.push(this.singlePageSurface);
     }
+    if (this.spreadPageSurface) {
+      surfaces.push(this.spreadPageSurface);
+    }
     return surfaces;
   }
 
-  private getSelectedText(): string {
+  private captureSelectionHighlights(): SelectionHighlightData[] {
     const selection = window.getSelection();
     if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
-      return '';
+      return [];
     }
 
-    let belongsToViewer = false;
-    for (let i = 0; i < selection.rangeCount; i++) {
-      const range = selection.getRangeAt(i);
-      if (this.containsPdfSurfaceNode(range.commonAncestorContainer)) {
-        belongsToViewer = true;
-        break;
+    const selectedText = selection.toString().trim();
+    if (!selectedText) return [];
+
+    const highlights: SelectionHighlightData[] = [];
+    for (const surface of this.getPageSurfaces()) {
+      if (!surface.viewport || surface.pageNumber === null) continue;
+
+      const wrapperRect = surface.wrapper.getBoundingClientRect();
+      const pdfRects: PdfAnnotationRect[] = [];
+
+      for (let rangeIndex = 0; rangeIndex < selection.rangeCount; rangeIndex++) {
+        const range = selection.getRangeAt(rangeIndex);
+        if (!range.intersectsNode(surface.textLayer)) continue;
+
+        for (const clientRect of Array.from(range.getClientRects())) {
+          const left = Math.max(clientRect.left, wrapperRect.left);
+          const top = Math.max(clientRect.top, wrapperRect.top);
+          const right = Math.min(clientRect.right, wrapperRect.right);
+          const bottom = Math.min(clientRect.bottom, wrapperRect.bottom);
+          if (right <= left || bottom <= top) continue;
+
+          const [pdfX1, pdfY1] = surface.viewport.convertToPdfPoint(
+            left - wrapperRect.left,
+            top - wrapperRect.top,
+          );
+          const [pdfX2, pdfY2] = surface.viewport.convertToPdfPoint(
+            right - wrapperRect.left,
+            bottom - wrapperRect.top,
+          );
+          pdfRects.push({
+            x1: Math.min(pdfX1, pdfX2),
+            y1: Math.min(pdfY1, pdfY2),
+            x2: Math.max(pdfX1, pdfX2),
+            y2: Math.max(pdfY1, pdfY2),
+          });
+        }
+      }
+
+      if (pdfRects.length > 0) {
+        highlights.push({
+          pageNumber: surface.pageNumber,
+          rects: pdfRects,
+          text: selectedText,
+        });
       }
     }
 
-    if (!belongsToViewer) {
-      belongsToViewer =
-        Boolean(selection.anchorNode && this.containsPdfSurfaceNode(selection.anchorNode)) ||
-        Boolean(selection.focusNode && this.containsPdfSurfaceNode(selection.focusNode));
-    }
-
-    return belongsToViewer ? selection.toString().trim() : '';
+    return highlights;
   }
 
-  private containsPdfSurfaceNode(node: Node): boolean {
-    if (this.singlePageSurface?.wrapper.contains(node)) {
-      return true;
-    }
+  private addPendingSelectionHighlights(note: string): void {
+    const timestamp = Date.now();
+    const additions = this.pendingSelectionHighlights.map<PdfAnnotation>((selection) => ({
+      id: crypto.randomUUID(),
+      kind: 'highlight',
+      pageNumber: selection.pageNumber,
+      rects: selection.rects,
+      text: selection.text,
+      note,
+      color: 'yellow',
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }));
+    this.pendingSelectionHighlights = [];
+    if (additions.length === 0) return;
 
-    for (const surface of this.pageSurfaces.values()) {
-      if (surface.wrapper.contains(node)) {
-        return true;
-      }
-    }
+    this.annotations = [...this.annotations, ...additions];
+    this.refreshUserAnnotationLayers();
+    this.notifyAnnotationsChanged();
+    window.getSelection()?.removeAllRanges();
+  }
 
-    return false;
+  private renderUserAnnotations(surface: PageSurface, viewport: PageViewport): void {
+    surface.userAnnotationLayer.replaceChildren();
+    if (surface.pageNumber === null) return;
+
+    for (const annotation of this.annotations) {
+      if (annotation.pageNumber !== surface.pageNumber) continue;
+
+      annotation.rects.forEach((rect, rectIndex) => {
+        const [x1, y1, x2, y2] = viewport.convertToViewportRectangle([
+          rect.x1,
+          rect.y1,
+          rect.x2,
+          rect.y2,
+        ]);
+        const highlight = document.createElement('button');
+        highlight.type = 'button';
+        highlight.className = `user-annotation user-annotation-${annotation.kind}`;
+        highlight.dataset.annotationColor = annotation.color;
+        highlight.dataset.annotationId = annotation.id;
+        highlight.style.left = `${Math.min(x1, x2)}px`;
+        highlight.style.top = `${Math.min(y1, y2)}px`;
+        highlight.style.width = `${Math.max(Math.abs(x2 - x1), 4)}px`;
+        highlight.style.height = `${Math.max(Math.abs(y2 - y1), 4)}px`;
+        highlight.title =
+          annotation.note || annotation.text || `Annotation on page ${annotation.pageNumber}`;
+        highlight.setAttribute('aria-label', highlight.title);
+
+        if (rectIndex === 0 && annotation.note) {
+          highlight.classList.add('has-note');
+        }
+        highlight.addEventListener('click', (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          this.onAnnotationsChange?.(this.getAnnotations());
+        });
+        surface.userAnnotationLayer.appendChild(highlight);
+      });
+    }
+  }
+
+  private refreshUserAnnotationLayers(): void {
+    for (const surface of this.getPageSurfaces()) {
+      if (surface.viewport) this.renderUserAnnotations(surface, surface.viewport);
+    }
+  }
+
+  private notifyAnnotationsChanged(): void {
+    this.onAnnotationsChange?.(this.getAnnotations());
+  }
+
+  setAnnotations(annotations: readonly PdfAnnotation[]): void {
+    this.annotations = annotations.map((annotation) => ({
+      ...annotation,
+      rects: annotation.rects.map((rect) => ({ ...rect })),
+    }));
+    this.refreshUserAnnotationLayers();
+  }
+
+  getAnnotations(): PdfAnnotation[] {
+    return this.annotations.map((annotation) => ({
+      ...annotation,
+      rects: annotation.rects.map((rect) => ({ ...rect })),
+    }));
+  }
+
+  async addPageNote(note: string): Promise<void> {
+    const surface = this.getSurfaceForPage(this.state.currentPage);
+    const viewport = surface?.viewport;
+    if (!viewport || !note.trim()) return;
+
+    const [pdfX1, pdfY1] = viewport.convertToPdfPoint(viewport.width - 32, 20);
+    const [pdfX2, pdfY2] = viewport.convertToPdfPoint(viewport.width - 12, 40);
+    const timestamp = Date.now();
+    this.annotations = [
+      ...this.annotations,
+      {
+        id: crypto.randomUUID(),
+        kind: 'note',
+        pageNumber: this.state.currentPage,
+        rects: [
+          {
+            x1: Math.min(pdfX1, pdfX2),
+            y1: Math.min(pdfY1, pdfY2),
+            x2: Math.max(pdfX1, pdfX2),
+            y2: Math.max(pdfY1, pdfY2),
+          },
+        ],
+        text: '',
+        note: note.trim(),
+        color: 'yellow',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ];
+    this.refreshUserAnnotationLayers();
+    this.notifyAnnotationsChanged();
+  }
+
+  updateAnnotation(
+    annotationId: string,
+    updates: { note?: string; color?: PdfAnnotationColor },
+  ): void {
+    let changed = false;
+    this.annotations = this.annotations.map((annotation) => {
+      if (annotation.id !== annotationId) return annotation;
+      changed = true;
+      return { ...annotation, ...updates, updatedAt: Date.now() };
+    });
+    if (!changed) return;
+    this.refreshUserAnnotationLayers();
+    this.notifyAnnotationsChanged();
+  }
+
+  removeAnnotation(annotationId: string): void {
+    const next = this.annotations.filter((annotation) => annotation.id !== annotationId);
+    if (next.length === this.annotations.length) return;
+    this.annotations = next;
+    this.refreshUserAnnotationLayers();
+    this.notifyAnnotationsChanged();
+  }
+
+  private getSurfaceForPage(pageNumber: number): PageSurface | null {
+    if (this.singlePageSurface?.pageNumber === pageNumber) return this.singlePageSurface;
+    if (this.spreadPageSurface?.pageNumber === pageNumber) return this.spreadPageSurface;
+    return this.pageSurfaces.get(pageNumber) ?? null;
   }
 
   private async copyLinkTarget(target: PdfLinkTarget): Promise<void> {
@@ -725,6 +1043,175 @@ export class PDFViewer {
       document.execCommand('copy');
       document.body.removeChild(textArea);
     }
+  }
+
+  private async getPageText(pageNumber: number): Promise<string> {
+    const cached = this.pageTextCache.get(pageNumber);
+    if (cached !== undefined) return cached;
+    if (!this.pdfDoc) return '';
+
+    const page = await this.pdfDoc.getPage(pageNumber);
+    const content = await page.getTextContent();
+    const text = content.items
+      .map((item) => ('str' in item && typeof item.str === 'string' ? item.str : ''))
+      .join(' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    this.pageTextCache.set(pageNumber, text);
+    return text;
+  }
+
+  async searchText(query: string): Promise<PdfSearchMatch[]> {
+    const normalizedQuery = query.trim();
+    this.searchQuery = normalizedQuery;
+    this.searchMatches = [];
+    this.activeSearchMatch = null;
+    this.refreshSearchHighlights();
+    if (!normalizedQuery || !this.pdfDoc) return [];
+
+    const matches: PdfSearchMatch[] = [];
+    for (let pageNumber = 1; pageNumber <= this.state.totalPages; pageNumber++) {
+      if (this.searchQuery !== normalizedQuery) return [];
+      const pageText = await this.getPageText(pageNumber);
+      if (this.searchQuery !== normalizedQuery) return [];
+      matches.push(...findPageTextMatches(pageText, normalizedQuery, pageNumber));
+    }
+
+    if (this.searchQuery !== normalizedQuery) return [];
+    this.searchMatches = matches;
+    return matches.map((match) => ({ ...match }));
+  }
+
+  async revealSearchMatch(match: PdfSearchMatch): Promise<void> {
+    this.activeSearchMatch = { ...match };
+    await this.goToPage(match.pageNumber);
+    this.refreshSearchHighlights();
+
+    window.requestAnimationFrame(() => {
+      const activeMark = this.container.querySelector<HTMLElement>(
+        '.pdf-search-hit[aria-current="true"]',
+      );
+      activeMark?.scrollIntoView({ block: 'center', inline: 'nearest' });
+    });
+  }
+
+  getSearchMatches(): PdfSearchMatch[] {
+    return this.searchMatches.map((match) => ({ ...match }));
+  }
+
+  clearSearch(): void {
+    this.searchQuery = '';
+    this.searchMatches = [];
+    this.activeSearchMatch = null;
+    this.refreshSearchHighlights();
+  }
+
+  private refreshSearchHighlights(): void {
+    for (const surface of this.getPageSurfaces()) {
+      this.applySearchHighlights(surface);
+    }
+  }
+
+  private applySearchHighlights(surface: PageSurface): void {
+    const textSpans = Array.from(surface.textLayer.querySelectorAll<HTMLElement>('span'));
+    for (const span of textSpans) {
+      const originalText = span.dataset.searchOriginalText;
+      if (originalText !== undefined) {
+        span.replaceChildren(originalText);
+        delete span.dataset.searchOriginalText;
+      }
+    }
+
+    const query = this.searchQuery.toLocaleLowerCase();
+    if (!query || surface.pageNumber === null) return;
+
+    let pageOccurrence = 0;
+    for (const span of textSpans) {
+      const originalText = span.textContent ?? '';
+      const normalizedText = originalText.toLocaleLowerCase();
+      if (!normalizedText.includes(query)) continue;
+
+      span.dataset.searchOriginalText = originalText;
+      span.replaceChildren();
+      let cursor = 0;
+
+      while (cursor <= normalizedText.length - query.length) {
+        const index = normalizedText.indexOf(query, cursor);
+        if (index === -1) break;
+        if (index > cursor) span.append(originalText.slice(cursor, index));
+
+        const mark = document.createElement('mark');
+        mark.className = 'pdf-search-hit';
+        mark.textContent = originalText.slice(index, index + query.length);
+        const isActive =
+          this.activeSearchMatch?.pageNumber === surface.pageNumber &&
+          this.activeSearchMatch.pageOccurrence === pageOccurrence;
+        if (isActive) {
+          mark.classList.add('pdf-search-hit-active');
+          mark.setAttribute('aria-current', 'true');
+        }
+        span.appendChild(mark);
+        pageOccurrence += 1;
+        cursor = index + query.length;
+      }
+
+      if (cursor < originalText.length) span.append(originalText.slice(cursor));
+    }
+  }
+
+  async getOutlineItems(): Promise<PdfOutlineItem[]> {
+    if (!this.pdfDoc) return [];
+    const outline = (await this.pdfDoc.getOutline()) as unknown as RawOutlineItem[];
+
+    const resolveItems = async (items: RawOutlineItem[]): Promise<PdfOutlineItem[]> =>
+      Promise.all(
+        items.map(async (item) => ({
+          title: item.title || 'Untitled section',
+          pageNumber: item.dest ? await this.resolveDestinationPage(item.dest) : null,
+          url: item.url ?? item.unsafeUrl,
+          bold: item.bold,
+          italic: item.italic,
+          items: await resolveItems(item.items ?? []),
+        })),
+      );
+
+    return resolveItems(outline ?? []);
+  }
+
+  async activateOutlineItem(item: PdfOutlineItem): Promise<void> {
+    if (item.pageNumber !== null) {
+      await this.goToPage(item.pageNumber);
+      return;
+    }
+    if (item.url) {
+      await this.activateLinkTarget({ url: item.url });
+    }
+  }
+
+  async renderThumbnail(pageNumber: number, maxWidth = 144): Promise<HTMLCanvasElement> {
+    if (!this.pdfDoc) throw new Error('PDF not loaded');
+    const page = await this.pdfDoc.getPage(pageNumber);
+    const baseViewport = page.getViewport({ scale: 1, rotation: this.state.rotation });
+    const scale = Math.min(maxWidth / baseViewport.width, 1);
+    const viewport = page.getViewport({ scale, rotation: this.state.rotation });
+    const canvas = document.createElement('canvas');
+    const outputScale = Math.min(window.devicePixelRatio || 1, 2);
+    canvas.width = Math.max(1, Math.floor(viewport.width * outputScale));
+    canvas.height = Math.max(1, Math.floor(viewport.height * outputScale));
+    canvas.style.width = `${Math.floor(viewport.width)}px`;
+    canvas.style.height = `${Math.floor(viewport.height)}px`;
+    canvas.style.filter = this.currentFilterCSS;
+    const context = canvas.getContext('2d', { alpha: false });
+    if (!context) throw new Error('Could not render page thumbnail');
+    context.fillStyle = '#ffffff';
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    const task = page.render({
+      canvasContext: context,
+      viewport,
+      transform: outputScale === 1 ? undefined : [outputScale, 0, 0, outputScale, 0, 0],
+    } as unknown as Parameters<PDFPageProxy['render']>[0]);
+    await task.promise;
+    return canvas;
   }
 
   async renderPage(pageNum: number): Promise<void> {
@@ -796,6 +1283,7 @@ export class PDFViewer {
       this.canvas.height = canvasHeight;
       this.canvas.style.width = `${pageWidth}px`;
       this.canvas.style.height = `${pageHeight}px`;
+      this.singlePageSurface.pageNumber = pageNum;
       this.configurePageSurface(this.singlePageSurface, pageWidth, pageHeight, viewport);
       const targetContext = this.canvas.getContext('2d', { alpha: false });
       targetContext?.drawImage(renderCanvas, 0, 0);
@@ -806,6 +1294,12 @@ export class PDFViewer {
       this.state.currentPage = pageNum;
       if (prevPage !== pageNum) {
         this.onPageChange?.(pageNum);
+      }
+
+      if (this.state.viewMode === 'spread') {
+        await this.renderSpreadCompanion(pageNum + 1);
+      } else if (this.spreadPageSurface) {
+        this.spreadPageSurface.wrapper.style.display = 'none';
       }
 
       console.log(`Rendered page ${pageNum}/${this.state.totalPages}`);
@@ -824,15 +1318,97 @@ export class PDFViewer {
     }
   }
 
+  private ensureSpreadSurface(): PageSurface {
+    if (!this.spreadPageSurface) {
+      this.spreadPageSurface = this.createPageSurface(`${this.canvasId}-spread`);
+      this.spreadPageSurface.wrapper.classList.add('spread-secondary');
+      this.container.appendChild(this.spreadPageSurface.wrapper);
+    }
+    return this.spreadPageSurface;
+  }
+
+  private async renderSpreadCompanion(pageNumber: number): Promise<void> {
+    if (!this.pdfDoc) return;
+    const surface = this.ensureSpreadSurface();
+    if (pageNumber > this.state.totalPages) {
+      surface.pageNumber = null;
+      surface.wrapper.style.display = 'none';
+      return;
+    }
+
+    if (this.spreadRenderTask) {
+      this.spreadRenderTask.cancel();
+      this.spreadRenderTask = null;
+    }
+
+    try {
+      const page = await this.pdfDoc.getPage(pageNumber);
+      this.cacheBaseDimensions(pageNumber, page);
+      const viewport = page.getViewport({
+        scale: this.state.zoom,
+        rotation: this.state.rotation,
+      });
+      const context = surface.canvas.getContext('2d', { alpha: false });
+      if (!context) return;
+
+      const outputScale = getOutputScale(viewport.width, viewport.height);
+      const sfx = approximateFraction(outputScale.sx);
+      const sfy = approximateFraction(outputScale.sy);
+      const canvasWidth = floorToDivide(calcRound(viewport.width * outputScale.sx), sfx[0]);
+      const canvasHeight = floorToDivide(calcRound(viewport.height * outputScale.sy), sfy[0]);
+      const pageWidth = floorToDivide(calcRound(viewport.width), sfx[1]);
+      const pageHeight = floorToDivide(calcRound(viewport.height), sfy[1]);
+
+      surface.canvas.width = canvasWidth;
+      surface.canvas.height = canvasHeight;
+      surface.canvas.style.width = `${pageWidth}px`;
+      surface.canvas.style.height = `${pageHeight}px`;
+      surface.canvas.style.filter = this.currentFilterCSS;
+      surface.pageNumber = pageNumber;
+      this.configurePageSurface(surface, pageWidth, pageHeight, viewport);
+      context.fillStyle = '#ffffff';
+      context.fillRect(0, 0, canvasWidth, canvasHeight);
+      outputScale.sx = canvasWidth / pageWidth;
+      outputScale.sy = canvasHeight / pageHeight;
+
+      const renderTask = page.render({
+        canvasContext: context,
+        viewport,
+        transform:
+          outputScale.sx !== 1 || outputScale.sy !== 1
+            ? [outputScale.sx, 0, 0, outputScale.sy, 0, 0]
+            : undefined,
+      } as unknown as Parameters<PDFPageProxy['render']>[0]);
+      this.spreadRenderTask = renderTask;
+      await renderTask.promise;
+      if (this.spreadRenderTask !== renderTask) return;
+      this.spreadRenderTask = null;
+      await this.renderInteractiveLayers(page, viewport, surface);
+      surface.wrapper.style.display = this.isVisible ? 'block' : 'none';
+    } catch (error) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'name' in error &&
+        error.name === 'RenderingCancelledException'
+      ) {
+        return;
+      }
+      throw error;
+    }
+  }
+
   async nextPage(): Promise<void> {
+    const step = this.state.viewMode === 'spread' ? 2 : 1;
     if (this.state.currentPage < this.state.totalPages) {
-      await this.goToPage(this.state.currentPage + 1);
+      await this.goToPage(Math.min(this.state.currentPage + step, this.state.totalPages));
     }
   }
 
   async previousPage(): Promise<void> {
+    const step = this.state.viewMode === 'spread' ? 2 : 1;
     if (this.state.currentPage > 1) {
-      await this.goToPage(this.state.currentPage - 1);
+      await this.goToPage(Math.max(this.state.currentPage - step, 1));
     }
   }
 
@@ -905,6 +1481,58 @@ export class PDFViewer {
     }
   }
 
+  private handleWheel(event: WheelEvent): void {
+    if (!event.ctrlKey && !event.metaKey) return;
+    event.preventDefault();
+    this.pendingWheelDelta += event.deltaY;
+    if (this.wheelZoomRafId !== null) return;
+
+    const clientX = event.clientX;
+    const clientY = event.clientY;
+    this.wheelZoomRafId = window.requestAnimationFrame(() => {
+      this.wheelZoomRafId = null;
+      const delta = this.pendingWheelDelta;
+      this.pendingWheelDelta = 0;
+      const targetZoom = this.state.zoom * Math.exp(-delta * 0.002);
+      void this.zoomAtPoint(targetZoom, clientX, clientY);
+    });
+  }
+
+  private handleGestureStart(event: Event): void {
+    event.preventDefault();
+    this.pinchStartZoom = this.state.zoom;
+  }
+
+  private handleGestureChange(event: Event): void {
+    const gesture = event as GestureLikeEvent;
+    if (!gesture.scale || !Number.isFinite(gesture.scale)) return;
+    event.preventDefault();
+    const rect = this.container.getBoundingClientRect();
+    void this.zoomAtPoint(
+      this.pinchStartZoom * gesture.scale,
+      rect.left + rect.width / 2,
+      rect.top + rect.height / 2,
+    );
+  }
+
+  private async zoomAtPoint(targetZoom: number, clientX: number, clientY: number): Promise<void> {
+    const epoch = ++this.pinchRenderEpoch;
+    const oldZoom = this.state.zoom;
+    const rect = this.container.getBoundingClientRect();
+    const localX = clientX - rect.left;
+    const localY = clientY - rect.top;
+    const documentX = (this.container.scrollLeft + localX) / oldZoom;
+    const documentY = (this.container.scrollTop + localY) / oldZoom;
+
+    await this.setZoom(targetZoom);
+    if (epoch !== this.pinchRenderEpoch) return;
+
+    const scale = this.state.zoom;
+    this.container.scrollLeft = Math.max(0, documentX * scale - localX);
+    this.container.scrollTop = Math.max(0, documentY * scale - localY);
+    this.onScrollChange?.(this.container.scrollTop);
+  }
+
   async setZoom(zoom: number): Promise<void> {
     const clamped = Math.max(0.25, Math.min(zoom, 5.0));
     if (!hasValueChanged(this.state.zoom, clamped)) return;
@@ -940,7 +1568,10 @@ export class PDFViewer {
       const viewport = page.getViewport({ scale: 1.0, rotation: this.state.rotation });
       baseWidth = viewport.width;
     }
-    const containerWidth = this.container.clientWidth - 40; // 20px padding each side
+    const containerWidth =
+      this.state.viewMode === 'spread'
+        ? (this.container.clientWidth - 52) / 2
+        : this.container.clientWidth - 40;
 
     this.state.zoom = containerWidth / baseWidth;
 
@@ -973,7 +1604,10 @@ export class PDFViewer {
       baseWidth = viewport.width;
       baseHeight = viewport.height;
     }
-    const containerWidth = this.container.clientWidth - 40;
+    const containerWidth =
+      this.state.viewMode === 'spread'
+        ? (this.container.clientWidth - 52) / 2
+        : this.container.clientWidth - 40;
     const containerHeight = this.container.clientHeight - 40;
 
     const widthScale = containerWidth / baseWidth;
@@ -994,6 +1628,9 @@ export class PDFViewer {
 
     if (this.canvas) {
       this.canvas.style.filter = filterCSS;
+    }
+    if (this.spreadPageSurface) {
+      this.spreadPageSurface.canvas.style.filter = filterCSS;
     }
 
     if (this.state.viewMode === 'continuous') {
@@ -1033,21 +1670,35 @@ export class PDFViewer {
    * Show or hide the entire viewer (both single-page canvas and continuous scroll wrapper)
    */
   setVisible(visible: boolean): void {
+    this.isVisible = visible;
     if (!visible) {
       this.hideContextMenu();
     }
 
     if (visible && !this.isScrollListenerAttached) {
       this.container.addEventListener('scroll', this.handleScrollBound);
+      this.container.addEventListener('wheel', this.handleWheelBound, { passive: false });
+      this.container.addEventListener('gesturestart', this.handleGestureStartBound);
+      this.container.addEventListener('gesturechange', this.handleGestureChangeBound);
       this.isScrollListenerAttached = true;
     } else if (!visible && this.isScrollListenerAttached) {
       this.container.removeEventListener('scroll', this.handleScrollBound);
+      this.container.removeEventListener('wheel', this.handleWheelBound);
+      this.container.removeEventListener('gesturestart', this.handleGestureStartBound);
+      this.container.removeEventListener('gesturechange', this.handleGestureChangeBound);
       this.isScrollListenerAttached = false;
       if (this.scrollRafId !== null) {
         window.cancelAnimationFrame(this.scrollRafId);
         this.scrollRafId = null;
       }
+      if (this.wheelZoomRafId !== null) {
+        window.cancelAnimationFrame(this.wheelZoomRafId);
+        this.wheelZoomRafId = null;
+      }
+      this.pendingWheelDelta = 0;
     }
+
+    if (visible) this.applyViewModeClasses();
 
     if (this.state.viewMode === 'continuous') {
       // In continuous mode, show/hide the scroll wrapper
@@ -1058,10 +1709,18 @@ export class PDFViewer {
       if (this.singlePageSurface) {
         this.singlePageSurface.wrapper.style.display = 'none';
       }
+      if (this.spreadPageSurface) {
+        this.spreadPageSurface.wrapper.style.display = 'none';
+      }
     } else {
       // In single-page mode, show/hide the main canvas
       if (this.singlePageSurface) {
         this.singlePageSurface.wrapper.style.display = visible ? 'block' : 'none';
+      }
+      if (this.spreadPageSurface) {
+        const showCompanion =
+          visible && this.state.viewMode === 'spread' && this.spreadPageSurface.pageNumber !== null;
+        this.spreadPageSurface.wrapper.style.display = showCompanion ? 'block' : 'none';
       }
       // Keep scroll wrapper hidden
       if (this.scrollContainer) {
@@ -1132,10 +1791,14 @@ export class PDFViewer {
 
   // ========== Continuous Scroll Methods ==========
 
-  async setViewMode(mode: 'single' | 'continuous'): Promise<void> {
+  async setViewMode(mode: ViewMode): Promise<void> {
     if (this.state.viewMode === mode) return;
 
     const currentPage = this.state.currentPage;
+    const previousMode = this.state.viewMode;
+    if (previousMode === 'continuous') {
+      this.cleanupContinuousScroll();
+    }
     this.state.viewMode = mode;
 
     if (mode === 'continuous') {
@@ -1148,12 +1811,16 @@ export class PDFViewer {
       // Ensure visibility is correct
       this.setVisible(true);
     } else {
-      this.cleanupContinuousScroll();
-      // Render single page
+      this.applyViewModeClasses();
       await this.renderPage(currentPage);
-      // Ensure visibility is correct
       this.setVisible(true);
     }
+  }
+
+  private applyViewModeClasses(): void {
+    if (!this.isVisible) return;
+    this.container.classList.toggle('continuous-scroll', this.state.viewMode === 'continuous');
+    this.container.classList.toggle('spread-view', this.state.viewMode === 'spread');
   }
 
   private async initializeContinuousScroll(): Promise<void> {
@@ -1607,8 +2274,16 @@ export class PDFViewer {
     document.removeEventListener('selectionchange', this.handleSelectionChangeBound);
     if (this.isScrollListenerAttached) {
       this.container.removeEventListener('scroll', this.handleScrollBound);
+      this.container.removeEventListener('wheel', this.handleWheelBound);
+      this.container.removeEventListener('gesturestart', this.handleGestureStartBound);
+      this.container.removeEventListener('gesturechange', this.handleGestureChangeBound);
       this.isScrollListenerAttached = false;
     }
+    if (this.wheelZoomRafId !== null) {
+      window.cancelAnimationFrame(this.wheelZoomRafId);
+      this.wheelZoomRafId = null;
+    }
+    this.pendingWheelDelta = 0;
     if (this.contextMenu?.parentNode) {
       this.contextMenu.parentNode.removeChild(this.contextMenu);
     }
@@ -1622,12 +2297,17 @@ export class PDFViewer {
     if (this.renderTask) {
       this.renderTask.cancel();
     }
+    if (this.spreadRenderTask) {
+      this.spreadRenderTask.cancel();
+    }
     this.disposePageSurface(this.singlePageSurface);
+    this.disposePageSurface(this.spreadPageSurface);
     if (this.pdfDoc) {
       this.pdfDoc.destroy();
     }
     this.pdfDoc = null;
     this.canvas = null;
     this.singlePageSurface = null;
+    this.spreadPageSurface = null;
   }
 }

--- a/src/scripts/pdf-viewer.ts
+++ b/src/scripts/pdf-viewer.ts
@@ -147,6 +147,7 @@ export class PDFViewer {
   private canvasId: string;
   private currentFilterCSS = '';
   private onPageChange: ((pageNum: number) => void) | null = null;
+  private onScrollChange: ((scrollPosition: number) => void) | null = null;
   private readonly linkTargets = new WeakMap<HTMLElement, PdfLinkTarget>();
   private contextMenu: HTMLDivElement | null = null;
   private handleDocumentPointerDownBound: (event: PointerEvent) => void;
@@ -174,6 +175,7 @@ export class PDFViewer {
   private readonly renderBufferPages = 2;
   private readonly cleanupBufferPages = 5;
   private handleScrollBound: () => void;
+  private isScrollListenerAttached = false;
 
   constructor(containerId: string, canvasId: string = 'pdf-canvas') {
     const container = document.getElementById(containerId);
@@ -196,6 +198,10 @@ export class PDFViewer {
 
   setOnPageChange(handler: ((pageNum: number) => void) | null): void {
     this.onPageChange = handler;
+  }
+
+  setOnScrollChange(handler: ((scrollPosition: number) => void) | null): void {
+    this.onScrollChange = handler;
   }
 
   private initializeCanvas(): void {
@@ -297,18 +303,8 @@ export class PDFViewer {
       this.state.fileName = fileName;
       this.state.filePath = filePath;
 
-      // Cache base dimensions (scale=1, rotation=0) for all pages
+      // Render page one immediately. Other dimensions are cached lazily as pages are requested.
       this.baseDimensions.clear();
-      for (let pageNum = 1; pageNum <= this.pdfDoc.numPages; pageNum++) {
-        const page = await this.pdfDoc.getPage(pageNum);
-        const viewport = page.getViewport({ scale: 1.0, rotation: 0 });
-        this.baseDimensions.set(pageNum, {
-          width: viewport.width,
-          height: viewport.height,
-        });
-      }
-
-      // Render first page
       await this.renderPage(1);
 
       console.log(`Loaded PDF: ${fileName} (${this.state.totalPages} pages)`);
@@ -749,6 +745,7 @@ export class PDFViewer {
 
       // Get page
       const page: PDFPageProxy = await this.pdfDoc.getPage(pageNum);
+      this.cacheBaseDimensions(pageNum, page);
 
       // Calculate viewport with zoom and rotation
       const viewport = page.getViewport({
@@ -859,22 +856,24 @@ export class PDFViewer {
   }
 
   async rotateClockwise(): Promise<void> {
-    this.state.rotation = (this.state.rotation + 90) % 360;
-
-    if (this.state.viewMode === 'continuous') {
-      await this.calculateAllPageDimensions();
-      await this.renderVisiblePages(true);
-    } else {
-      await this.renderPage(this.state.currentPage);
-    }
+    await this.setRotation(this.state.rotation + 90);
   }
 
   async rotateCounterClockwise(): Promise<void> {
-    this.state.rotation = (this.state.rotation - 90 + 360) % 360;
+    await this.setRotation(this.state.rotation - 90);
+  }
 
+  async setRotation(rotation: number): Promise<void> {
+    const finiteRotation = Number.isFinite(rotation) ? rotation : 0;
+    const normalized = (((Math.round(finiteRotation / 90) * 90) % 360) + 360) % 360;
+    if (this.state.rotation === normalized) return;
+
+    const currentPage = this.state.currentPage;
+    this.state.rotation = normalized;
     if (this.state.viewMode === 'continuous') {
       await this.calculateAllPageDimensions();
       await this.renderVisiblePages(true);
+      await this.scrollToPage(currentPage);
     } else {
       await this.renderPage(this.state.currentPage);
     }
@@ -1009,6 +1008,19 @@ export class PDFViewer {
     return { ...this.state };
   }
 
+  getScrollPosition(): number {
+    return this.container.scrollTop;
+  }
+
+  async setScrollPosition(scrollPosition: number): Promise<void> {
+    const normalized = Number.isFinite(scrollPosition) ? Math.max(scrollPosition, 0) : 0;
+    this.container.scrollTop = normalized;
+
+    if (this.state.viewMode === 'continuous') {
+      await this.renderVisiblePages();
+    }
+  }
+
   getCanvas(): HTMLCanvasElement | null {
     return this.canvas;
   }
@@ -1023,6 +1035,18 @@ export class PDFViewer {
   setVisible(visible: boolean): void {
     if (!visible) {
       this.hideContextMenu();
+    }
+
+    if (visible && !this.isScrollListenerAttached) {
+      this.container.addEventListener('scroll', this.handleScrollBound);
+      this.isScrollListenerAttached = true;
+    } else if (!visible && this.isScrollListenerAttached) {
+      this.container.removeEventListener('scroll', this.handleScrollBound);
+      this.isScrollListenerAttached = false;
+      if (this.scrollRafId !== null) {
+        window.cancelAnimationFrame(this.scrollRafId);
+        this.scrollRafId = null;
+      }
     }
 
     if (this.state.viewMode === 'continuous') {
@@ -1135,11 +1159,6 @@ export class PDFViewer {
   private async initializeContinuousScroll(): Promise<void> {
     if (!this.pdfDoc) return;
 
-    // Hide single-page canvas
-    if (this.singlePageSurface) {
-      this.singlePageSurface.wrapper.style.display = 'none';
-    }
-
     // Create scroll container if it doesn't exist
     if (!this.scrollContainer) {
       this.scrollContainer = document.createElement('div');
@@ -1147,20 +1166,16 @@ export class PDFViewer {
       this.container.appendChild(this.scrollContainer);
     }
 
-    // Add continuous-scroll class to container
-    this.container.classList.add('continuous-scroll');
-
-    // Calculate dimensions for all pages
+    // Keep the already-rendered first page visible while the continuous layout is measured.
     await this.calculateAllPageDimensions();
 
-    // Set up scroll listener
-    this.container.addEventListener('scroll', this.handleScrollBound);
+    if (this.singlePageSurface) {
+      this.singlePageSurface.wrapper.style.display = 'none';
+    }
+    this.container.classList.add('continuous-scroll');
   }
 
   private cleanupContinuousScroll(): void {
-    // Remove scroll listener
-    this.container.removeEventListener('scroll', this.handleScrollBound);
-
     if (this.scrollRafId !== null) {
       window.cancelAnimationFrame(this.scrollRafId);
       this.scrollRafId = null;
@@ -1199,8 +1214,23 @@ export class PDFViewer {
     this.renderedPages.clear();
     this.pageHeights.clear();
     this.pageWidths.clear();
-    this.baseDimensions.clear();
     this.offsetArray = [];
+  }
+
+  private cacheBaseDimensions(
+    pageNum: number,
+    page: PDFPageProxy,
+  ): {
+    width: number;
+    height: number;
+  } {
+    const cached = this.baseDimensions.get(pageNum);
+    if (cached) return cached;
+
+    const viewport = page.getViewport({ scale: 1.0, rotation: 0 });
+    const dimensions = { width: viewport.width, height: viewport.height };
+    this.baseDimensions.set(pageNum, dimensions);
+    return dimensions;
   }
 
   private async calculateAllPageDimensions(): Promise<void> {
@@ -1219,14 +1249,17 @@ export class PDFViewer {
         this.pageWidths.set(pageNum, Math.floor(scaled.width));
         this.pageHeights.set(pageNum, Math.floor(scaled.height));
       } else {
-        // Fallback: fetch from PDF.js (should only happen if cache wasn't populated)
+        // Lazily fetch and cache dimensions the first time a page needs layout.
         const page = await this.pdfDoc.getPage(pageNum);
-        const viewport = page.getViewport({
-          scale: this.state.zoom,
+        const dimensions = this.cacheBaseDimensions(pageNum, page);
+        const scaled = deriveScaledDimensions({
+          baseWidth: dimensions.width,
+          baseHeight: dimensions.height,
+          zoom: this.state.zoom,
           rotation: this.state.rotation,
         });
-        this.pageWidths.set(pageNum, Math.floor(viewport.width));
-        this.pageHeights.set(pageNum, Math.floor(viewport.height));
+        this.pageWidths.set(pageNum, Math.floor(scaled.width));
+        this.pageHeights.set(pageNum, Math.floor(scaled.height));
       }
     }
 
@@ -1383,6 +1416,7 @@ export class PDFViewer {
 
       // Get page
       const page = await this.pdfDoc.getPage(pageNum);
+      this.cacheBaseDimensions(pageNum, page);
 
       // Calculate viewport
       const viewport = page.getViewport({
@@ -1504,8 +1538,6 @@ export class PDFViewer {
   }
 
   private handleScroll(): void {
-    if (this.state.viewMode !== 'continuous') return;
-
     // Throttle scroll events
     if (this.scrollRafId !== null) {
       return;
@@ -1513,7 +1545,10 @@ export class PDFViewer {
 
     this.scrollRafId = window.requestAnimationFrame(() => {
       this.scrollRafId = null;
-      void this.renderVisiblePages();
+      this.onScrollChange?.(this.container.scrollTop);
+      if (this.state.viewMode === 'continuous') {
+        void this.renderVisiblePages();
+      }
     });
   }
 
@@ -1570,6 +1605,10 @@ export class PDFViewer {
     document.removeEventListener('pointerup', this.handleDocumentPointerUpBound, true);
     document.removeEventListener('keydown', this.handleDocumentKeyDownBound);
     document.removeEventListener('selectionchange', this.handleSelectionChangeBound);
+    if (this.isScrollListenerAttached) {
+      this.container.removeEventListener('scroll', this.handleScrollBound);
+      this.isScrollListenerAttached = false;
+    }
     if (this.contextMenu?.parentNode) {
       this.contextMenu.parentNode.removeChild(this.contextMenu);
     }

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -7,6 +7,8 @@ export interface SavedTabSession {
   filterSettings: FilterSettings;
   currentPage: number;
   zoom: number;
+  rotation?: number;
+  scrollPosition?: number;
   viewMode: 'single' | 'continuous';
 }
 

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -1,4 +1,5 @@
 import { Store } from '@tauri-apps/plugin-store';
+import type { PdfAnnotation, RecentFile, ViewMode } from '../lib/document-features';
 import type { FilterSettings } from './filters';
 
 export interface SavedTabSession {
@@ -9,7 +10,7 @@ export interface SavedTabSession {
   zoom: number;
   rotation?: number;
   scrollPosition?: number;
-  viewMode: 'single' | 'continuous';
+  viewMode: ViewMode;
 }
 
 export interface ReadingSession {
@@ -39,11 +40,13 @@ export interface MoonightSettings {
     defaultDarkMode: string; // preset name
     rememberLastFilter: boolean;
     restorePreviousSession: boolean;
-    defaultViewMode: 'single' | 'continuous';
+    defaultViewMode: ViewMode;
   };
   keybinds: Record<string, KeybindConfig>;
   lastFilter?: FilterSettings;
   lastSession?: ReadingSession;
+  recentFiles: RecentFile[];
+  annotations: Record<string, PdfAnnotation[]>;
 }
 
 /**
@@ -89,6 +92,11 @@ export const DEFAULT_SETTINGS: MoonightSettings = {
       displayName: 'Print',
       binds: ['CmdOrCtrl+P'],
       action: 'print',
+    },
+    Find: {
+      displayName: 'Find in Document',
+      binds: ['CmdOrCtrl+F'],
+      action: 'find',
     },
     ZoomIn: {
       displayName: 'Zoom In',
@@ -209,7 +217,14 @@ export const DEFAULT_SETTINGS: MoonightSettings = {
       binds: ['F11'],
       action: 'toggleFullscreen',
     },
+    PresentationMode: {
+      displayName: 'Presentation Mode',
+      binds: ['Shift+F11'],
+      action: 'presentationMode',
+    },
   },
+  recentFiles: [],
+  annotations: {},
 };
 
 /**

--- a/src/scripts/tabs.ts
+++ b/src/scripts/tabs.ts
@@ -12,6 +12,7 @@ export interface TabData {
   filterSettings: FilterSettings; // Current filter preset
   currentPage: number; // Current page number
   zoom: number; // Current zoom level
+  rotation: number; // Clockwise page rotation in degrees
   scrollPosition: number; // Scroll position
   viewMode: 'single' | 'continuous'; // View mode
 }
@@ -24,12 +25,12 @@ export class TabManager {
   private activeTabId: string | null = null;
   private pdfViewers: Map<string, PDFViewer> = new Map();
   private closedHistory: string[] = [];
-  private onTabChange: (tab: TabData | null) => void;
+  private onTabChange: (tab: TabData | null) => void | Promise<void>;
   private onActiveViewerStateChange?: () => void;
   private onTabsChanged?: () => void;
 
   constructor(
-    onTabChange: (tab: TabData | null) => void,
+    onTabChange: (tab: TabData | null) => void | Promise<void>,
     onActiveViewerStateChange?: () => void,
     onTabsChanged?: () => void,
   ) {
@@ -60,6 +61,7 @@ export class TabManager {
       filterSettings: { ...initialFilterSettings },
       currentPage: 1,
       zoom: 1.0,
+      rotation: 0,
       scrollPosition: 0,
       viewMode,
     };
@@ -72,6 +74,11 @@ export class TabManager {
     const viewer = new PDFViewer('pdf-container', canvasId);
     viewer.setOnPageChange(() => {
       if (this.activeTabId !== id) return;
+      this.onActiveViewerStateChange?.();
+    });
+    viewer.setOnScrollChange(() => {
+      if (this.activeTabId !== id) return;
+      tab.scrollPosition = viewer.getScrollPosition();
       this.onActiveViewerStateChange?.();
     });
 
@@ -124,7 +131,7 @@ export class TabManager {
       } else {
         // No tabs left
         this.activeTabId = null;
-        this.onTabChange(null);
+        await this.onTabChange(null);
       }
     }
 
@@ -142,6 +149,14 @@ export class TabManager {
     const tab = this.tabs.get(id);
     if (!tab) return;
 
+    if (this.activeTabId && this.activeTabId !== id) {
+      const previousTab = this.tabs.get(this.activeTabId);
+      const previousViewer = this.pdfViewers.get(this.activeTabId);
+      if (previousTab && previousViewer) {
+        previousTab.scrollPosition = previousViewer.getScrollPosition();
+      }
+    }
+
     // Show/hide all viewers (handles both single-page and continuous scroll modes)
     this.pdfViewers.forEach((viewer, viewerId) => {
       viewer.setVisible(viewerId === id);
@@ -154,7 +169,7 @@ export class TabManager {
     this.renderTabs();
 
     // Notify callback
-    this.onTabChange(tab);
+    await this.onTabChange(tab);
 
     console.log(`Activated tab: ${tab.title} (${id})`);
   }

--- a/src/scripts/tabs.ts
+++ b/src/scripts/tabs.ts
@@ -1,5 +1,6 @@
+import type { PdfAnnotation, ViewMode } from '../lib/document-features';
 import { type FilterSettings, PRESETS } from './filters';
-import { PDFViewer } from './pdf-viewer';
+import { type AnnotationNoteRequester, PDFViewer, type PdfPasswordRequester } from './pdf-viewer';
 
 /**
  * Data structure for a single tab
@@ -14,7 +15,16 @@ export interface TabData {
   zoom: number; // Current zoom level
   rotation: number; // Clockwise page rotation in degrees
   scrollPosition: number; // Scroll position
-  viewMode: 'single' | 'continuous'; // View mode
+  viewMode: ViewMode; // View mode
+  annotations: PdfAnnotation[];
+}
+
+interface TabManagerOptions {
+  getAnnotations?: (filePath: string) => readonly PdfAnnotation[];
+  onAnnotationsChanged?: (filePath: string, annotations: PdfAnnotation[]) => void;
+  onDocumentOpened?: (tab: TabData) => void;
+  requestPassword?: PdfPasswordRequester;
+  requestAnnotationNote?: AnnotationNoteRequester;
 }
 
 /**
@@ -28,15 +38,18 @@ export class TabManager {
   private onTabChange: (tab: TabData | null) => void | Promise<void>;
   private onActiveViewerStateChange?: () => void;
   private onTabsChanged?: () => void;
+  private options: TabManagerOptions;
 
   constructor(
     onTabChange: (tab: TabData | null) => void | Promise<void>,
     onActiveViewerStateChange?: () => void,
     onTabsChanged?: () => void,
+    options: TabManagerOptions = {},
   ) {
     this.onTabChange = onTabChange;
     this.onActiveViewerStateChange = onActiveViewerStateChange;
     this.onTabsChanged = onTabsChanged;
+    this.options = options;
   }
 
   /**
@@ -47,7 +60,7 @@ export class TabManager {
     title: string,
     pdfData: Uint8Array,
     filterSettings?: FilterSettings,
-    viewMode: 'single' | 'continuous' = 'single',
+    viewMode: ViewMode = 'single',
   ): Promise<TabData> {
     const id = crypto.randomUUID();
     const initialFilterSettings = filterSettings ?? PRESETS.default;
@@ -64,6 +77,11 @@ export class TabManager {
       rotation: 0,
       scrollPosition: 0,
       viewMode,
+      annotations:
+        this.options.getAnnotations?.(filePath).map((annotation) => ({
+          ...annotation,
+          rects: annotation.rects.map((rect) => ({ ...rect })),
+        })) ?? [],
     };
 
     // Store tab
@@ -71,7 +89,10 @@ export class TabManager {
 
     // Create PDF viewer for this tab
     const canvasId = `pdf-canvas-${id}`;
-    const viewer = new PDFViewer('pdf-container', canvasId);
+    const viewer = new PDFViewer('pdf-container', canvasId, {
+      requestPassword: this.options.requestPassword,
+      requestAnnotationNote: this.options.requestAnnotationNote,
+    });
     viewer.setOnPageChange(() => {
       if (this.activeTabId !== id) return;
       this.onActiveViewerStateChange?.();
@@ -81,9 +102,25 @@ export class TabManager {
       tab.scrollPosition = viewer.getScrollPosition();
       this.onActiveViewerStateChange?.();
     });
+    viewer.setAnnotations(tab.annotations);
+    viewer.setOnAnnotationsChange((annotations) => {
+      tab.annotations = annotations;
+      this.options.onAnnotationsChanged?.(filePath, annotations);
+      if (this.activeTabId === id) {
+        this.onActiveViewerStateChange?.();
+      }
+    });
 
-    // Load PDF
-    await viewer.loadPDF(pdfData, title, filePath);
+    // Load PDF. Keep tab creation transactional so cancelled passwords or invalid files
+    // do not leave a dead tab/surface behind.
+    try {
+      await viewer.loadPDF(pdfData, title, filePath);
+    } catch (error) {
+      viewer.destroy();
+      this.tabs.delete(id);
+      this.renderTabs();
+      throw error;
+    }
 
     // Store viewer
     this.pdfViewers.set(id, viewer);
@@ -97,6 +134,7 @@ export class TabManager {
 
     // Activate the new tab (this will show its canvas)
     await this.activateTab(id);
+    this.options.onDocumentOpened?.(tab);
 
     console.log(`Created tab: ${title} (${id})`);
     return tab;

--- a/src/styles/document-features.css
+++ b/src/styles/document-features.css
@@ -1,0 +1,383 @@
+#document-workspace {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+#document-workspace #pdf-container {
+  min-width: 0;
+}
+
+#toolbar > .toolbar-group {
+  flex-shrink: 0;
+}
+
+#toolbar > .toolbar-group.file-info {
+  flex-shrink: 1;
+}
+
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+}
+
+.search-bar label {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.search-bar input {
+  width: min(420px, 42vw);
+  height: 30px;
+  padding: 4px 9px;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+.search-bar input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+}
+
+.search-status {
+  min-width: 110px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.search-bar button,
+.sidebar-tabs button {
+  min-width: 30px;
+  height: 28px;
+  padding: 0 8px;
+  color: var(--text-primary);
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.search-bar button:hover,
+.sidebar-tabs button:hover {
+  border-color: var(--accent-color);
+  background: var(--bg-primary);
+}
+
+.document-sidebar {
+  display: flex;
+  flex: 0 0 248px;
+  flex-direction: column;
+  width: 248px;
+  min-width: 200px;
+  max-width: 38vw;
+  border-right: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+}
+
+.sidebar-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 7px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.sidebar-tabs button[aria-selected="true"] {
+  color: #fff;
+  background: var(--accent-color);
+  border-color: var(--accent-color);
+}
+
+.sidebar-tabs .sidebar-close {
+  min-width: 28px;
+  margin-left: auto;
+  padding: 0;
+}
+
+.sidebar-content {
+  flex: 1;
+  min-height: 0;
+  padding: 8px;
+  overflow: auto;
+}
+
+.sidebar-empty,
+.sidebar-loading {
+  padding: 20px 10px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.outline-list,
+.outline-list ul {
+  display: grid;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.outline-list ul {
+  padding-left: 14px;
+}
+
+.outline-item-button {
+  width: 100%;
+  padding: 6px 7px;
+  overflow: hidden;
+  color: var(--text-primary);
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.outline-item-button:hover {
+  background: var(--bg-primary);
+}
+
+.thumbnail-list {
+  display: grid;
+  gap: 12px;
+  justify-items: center;
+}
+
+.thumbnail-button {
+  display: grid;
+  gap: 5px;
+  justify-items: center;
+  width: 100%;
+  padding: 7px;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.thumbnail-button:hover,
+.thumbnail-button.active {
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border-color: var(--accent-color);
+}
+
+.thumbnail-button canvas {
+  max-width: 100%;
+  height: auto;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+
+.annotation-toolbar {
+  display: flex;
+  margin-bottom: 8px;
+}
+
+.annotation-add {
+  width: 100%;
+  padding: 7px 9px;
+  color: var(--text-primary);
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.annotation-card {
+  display: grid;
+  gap: 7px;
+  margin-bottom: 8px;
+  padding: 9px;
+  border: 1px solid var(--border-color);
+  border-left: 4px solid #f0cc3a;
+  border-radius: 6px;
+  background: var(--bg-primary);
+}
+
+.annotation-card[data-color="green"] {
+  border-left-color: #5fd275;
+}
+
+.annotation-card[data-color="blue"] {
+  border-left-color: #4c9fff;
+}
+
+.annotation-card[data-color="pink"] {
+  border-left-color: #f769b2;
+}
+
+.annotation-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.annotation-card blockquote {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+.annotation-card textarea {
+  width: 100%;
+  min-height: 54px;
+  padding: 6px;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font: inherit;
+  font-size: 12px;
+  resize: vertical;
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+.annotation-card-actions {
+  display: flex;
+  gap: 5px;
+}
+
+.annotation-card-actions button,
+.annotation-card-actions select {
+  padding: 4px 6px;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 11px;
+}
+
+.recent-files {
+  width: min(520px, calc(100vw - 48px));
+  margin-top: 28px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border-color);
+  text-align: left;
+}
+
+.recent-files-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.recent-files-heading h3 {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.recent-files-heading button {
+  color: var(--text-secondary);
+  background: transparent;
+  border: 0;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.recent-files-list {
+  display: grid;
+  gap: 4px;
+}
+
+.recent-file-button {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  width: 100%;
+  padding: 8px 10px;
+  color: var(--text-primary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.recent-file-button:hover {
+  background: var(--bg-secondary);
+  border-color: var(--border-color);
+}
+
+.recent-file-title,
+.recent-file-path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recent-file-path {
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+body.presentation-mode #toolbar,
+body.presentation-mode #tab-bar,
+body.presentation-mode #search-bar,
+body.presentation-mode #document-sidebar {
+  display: none !important;
+}
+
+body.presentation-mode #pdf-container {
+  padding: 0;
+  background: #000;
+}
+
+body.presentation-mode #pdf-container > .pdf-page-surface {
+  top: 0;
+}
+
+@media (max-width: 1250px) {
+  .preset-group,
+  .toolbar-group.file-info {
+    display: none;
+  }
+}
+
+@media (max-width: 900px) {
+  #toolbar {
+    justify-content: flex-start;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    scrollbar-width: none;
+  }
+
+  #toolbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .document-sidebar {
+    position: absolute;
+    z-index: 20;
+    inset: 0 auto 0 0;
+    max-width: 80vw;
+    box-shadow: 8px 0 24px rgba(0, 0, 0, 0.4);
+  }
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -112,6 +112,117 @@ body.pdf-loaded {
   font-family: "Monaco", "Courier New", monospace;
 }
 
+.app-dialog {
+  width: min(420px, calc(100vw - 40px));
+  padding: 0;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.5);
+}
+
+.app-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.58);
+}
+
+.app-dialog form {
+  display: grid;
+  gap: 16px;
+  padding: 22px;
+}
+
+.app-dialog h2 {
+  font-size: 20px;
+}
+
+.app-dialog p {
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.app-dialog label {
+  display: grid;
+  gap: 7px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.app-dialog input,
+.app-dialog textarea {
+  width: 100%;
+  padding: 9px 10px;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  font: inherit;
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+.app-dialog input:focus,
+.app-dialog textarea:focus {
+  outline: 2px solid color-mix(in srgb, var(--accent-color), transparent 35%);
+  border-color: var(--accent-color);
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.dialog-actions button {
+  min-width: 86px;
+  padding: 8px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.dialog-secondary {
+  background: transparent;
+}
+
+.dialog-primary {
+  background: var(--accent-color);
+  border-color: var(--accent-color) !important;
+}
+
+.toast-region {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: 12000;
+  display: grid;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.toast {
+  max-width: min(420px, calc(100vw - 36px));
+  padding: 10px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 7px;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.4);
+  transition:
+    opacity 0.18s ease,
+    transform 0.18s ease;
+}
+
+.toast-error {
+  border-color: #dc5c68;
+}
+
+.toast-leaving {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
 /* Remove loading indicator */
 .hidden {
   display: none !important;

--- a/src/styles/pdf-viewer.css
+++ b/src/styles/pdf-viewer.css
@@ -267,7 +267,7 @@
   text-align: initial;
   text-size-adjust: none;
   transform-origin: 0 0;
-  z-index: 1;
+  z-index: 2;
   --min-font-size: 1;
   --text-scale-factor: calc(var(--total-scale-factor) * var(--min-font-size));
   --min-font-size-inv: calc(1 / var(--min-font-size));
@@ -315,7 +315,7 @@
 #pdf-container .annotationLayer {
   position: absolute;
   inset: 0;
-  z-index: 2;
+  z-index: 3;
   pointer-events: none;
   transform-origin: 0 0;
 }
@@ -327,6 +327,67 @@
   transform-origin: 0 0;
   user-select: none;
   pointer-events: auto;
+}
+
+#pdf-container .user-annotation-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+#pdf-container .user-annotation {
+  position: absolute;
+  padding: 0;
+  border: 0;
+  border-radius: 2px;
+  background: rgba(255, 220, 58, 0.42);
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
+
+#pdf-container .user-annotation[data-annotation-color="green"] {
+  background: rgba(95, 210, 117, 0.4);
+}
+
+#pdf-container .user-annotation[data-annotation-color="blue"] {
+  background: rgba(76, 159, 255, 0.38);
+}
+
+#pdf-container .user-annotation[data-annotation-color="pink"] {
+  background: rgba(247, 105, 178, 0.4);
+}
+
+#pdf-container .user-annotation-note,
+#pdf-container .user-annotation.has-note {
+  min-width: 14px;
+  min-height: 14px;
+  border: 1px solid rgba(106, 76, 0, 0.6);
+  border-radius: 50%;
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+#pdf-container .user-annotation.has-note::after {
+  content: "•";
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: #6c4b00;
+  font-size: 12px;
+}
+
+#pdf-container .pdf-search-hit {
+  padding: 0;
+  color: transparent;
+  background: rgba(255, 204, 0, 0.4);
+}
+
+#pdf-container .pdf-search-hit-active {
+  background: rgba(255, 126, 0, 0.62);
+  outline: 1px solid rgba(154, 70, 0, 0.8);
 }
 
 #pdf-container .textLayer.selecting ~ .annotationLayer section {
@@ -428,4 +489,16 @@
 
 #pdf-container:not(.continuous-scroll) > .pdf-page-surface:not([data-page-num]) {
   display: block;
+}
+
+#pdf-container.spread-view > .spread-primary {
+  right: calc(50% + 6px);
+  left: auto;
+  transform: none;
+}
+
+#pdf-container.spread-view > .spread-secondary {
+  right: auto;
+  left: calc(50% + 6px);
+  transform: none;
 }


### PR DESCRIPTION
Repair keyboard shortcut routing by keeping configured binding IDs separate from shared action names, retaining per-binding data for numbered tab shortcuts, normalizing Plus/Minus accelerators, and ignoring global shortcuts from editable controls.

Adopt the Tauri 2 webview drag/drop API and v2 payload shape, limit the reader and bundle associations to actual PDF documents, and replace placeholder Help menu destinations with the real Monight project pages.

Reduce cold-open latency by rendering page one before lazily caching later page dimensions. Persist rotation and precise scroll offsets across tab switches and restored sessions, and coordinate async tab activation so visual state is applied before UI refresh.

Add focused regression coverage for keybindings, drag/drop, initial PDF rendering, session geometry, supported extensions, bundle associations, and Help links. Include the full code-review report that documents the findings and follow-up roadmap.